### PR TITLE
Massive improvement in broker startup time when using jdbc persistence

### DIFF
--- a/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/ConsumerStateDAOImpl.java
+++ b/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/ConsumerStateDAOImpl.java
@@ -184,7 +184,8 @@ class ConsumerStateDAOImpl extends BaseDAOImpl implements ConsumerStateDAO {
             .toString();
 
         deleteByDstSQL = new StringBuffer(128)
-            .append( "DELETE FROM " ).append( tableName )
+            .append( "DELETE " ).append( tableName )
+            .append(" FROM " ).append( tableName )
             .append( " WHERE " )
             .append( MESSAGE_ID_COLUMN ).append( " IN " )
             .append( "(SELECT msgTbl." ).append( MessageDAO.ID_COLUMN )
@@ -202,7 +203,8 @@ class ConsumerStateDAOImpl extends BaseDAOImpl implements ConsumerStateDAO {
             .toString();
 
         deleteByDstBySessionSQL = new StringBuffer(128)
-            .append( "DELETE FROM " ).append( tableName )
+            .append( "DELETE " ).append( tableName )
+            .append( " FROM " ).append( tableName )
             .append( " WHERE " )
             .append( MESSAGE_ID_COLUMN ).append( " IN " )
             .append( "(SELECT msgTbl." ).append( MessageDAO.ID_COLUMN )

--- a/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/DestinationDAOImpl.java
+++ b/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/DestinationDAOImpl.java
@@ -127,7 +127,8 @@ class DestinationDAOImpl extends BaseDAOImpl implements DestinationDAO {
             .toString();
 
         deleteBySessionSQL = new StringBuffer(128)
-            .append( "DELETE FROM " ).append( tableName )
+            .append( "DELETE " ).append( tableName )
+            .append( " FROM " ).append( tableName )
             .append( " WHERE " )
             .append( ID_COLUMN ).append( " = ?" )
             .append(   " AND " )

--- a/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/MessageDAOImpl.java
+++ b/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/MessageDAOImpl.java
@@ -153,7 +153,8 @@ class MessageDAOImpl extends BaseDAOImpl implements MessageDAO {
             .toString();
 
         deleteByDstSQL = new StringBuffer(128)
-            .append( "DELETE FROM " ).append( tableName )
+            .append( "DELETE " ).append( tableName )
+            .append(" FROM " ).append( tableName )
             .append( " WHERE " )
             .append( DESTINATION_ID_COLUMN ).append( " = ?" )
             .append( " AND " )
@@ -166,7 +167,8 @@ class MessageDAOImpl extends BaseDAOImpl implements MessageDAO {
             .toString();
 
         deleteByDstBySessionSQL = new StringBuffer(128)
-            .append( "DELETE FROM " ).append( tableName )
+            .append( "DELETE " ).append( tableName )
+            .append( " FROM " ).append( tableName )
             .append( " WHERE " )
             .append( DESTINATION_ID_COLUMN ).append( " = ?" )
             .append( " AND " )

--- a/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/comm/CommBaseDAOImpl.java
+++ b/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/comm/CommBaseDAOImpl.java
@@ -390,7 +390,8 @@ public abstract class CommBaseDAOImpl implements BaseDAO {
                 .toString();
         } else {
             sql = new StringBuffer(128)
-                .append( "DELETE FROM " ).append( tableName )
+                .append( "DELETE ").append( tableName )
+                .append( " FROM " ).append( tableName )
                 .append( (whereClause != null && whereClause.length() > 0)
                          ? " WHERE " + whereClause : "" )
                 .toString();


### PR DESCRIPTION
Rewritten DELETE queries that run at broker startup. This way broker startup in a very crowded environment using an enhanced broker cluster is reduced from 3+hours to under 5 minutes.