### PR TITLE
FISH-642 Application Logging in Payara Server Breaks for Clustered Instances

### DIFF
--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-api/pom.xml
+++ b/mq/main/bridge/bridge-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-jms/pom.xml
+++ b/mq/main/bridge/bridge-jms/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-stomp/pom.xml
+++ b/mq/main/bridge/bridge-stomp/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/comm-io/pom.xml
+++ b/mq/main/comm-io/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/comm-util/pom.xml
+++ b/mq/main/comm-util/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/copyright/pom.xml
+++ b/mq/main/copyright/pom.xml
@@ -48,7 +48,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.mq</groupId>
     <artifactId>copyright</artifactId>
-    <version>5.1.1-SNAPSHOT</version>
+    <version>5.1.1.final.payara-p5-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>MQ copyright resources</name>
 

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-server/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-share/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel/pom.xml
+++ b/mq/main/http-tunnel/tunnel/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/jaxm-api/pom.xml
+++ b/mq/main/jaxm-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/logger/pom.xml
+++ b/mq/main/logger/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-cli/pom.xml
+++ b/mq/main/mq-admin/admin-cli/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-gui/pom.xml
+++ b/mq/main/mq-admin/admin-gui/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-comm/pom.xml
+++ b/mq/main/mq-broker/broker-comm/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/comm/CommGlobals.java
+++ b/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/comm/CommGlobals.java
@@ -136,6 +136,8 @@ public class CommGlobals
 
     private static ServiceLocator habitat = null;
 
+    // WORKAROUND - Payara FISH-642
+    // Property that forces inProcess and JMSRAManaged to return true when initialising the logger
     private static boolean forceManuallyConfigureLogging = false;
 
     public static void cleanupComm()
@@ -308,6 +310,13 @@ public class CommGlobals
         commBroker = b;
     }
 
+    /**
+     * WORKAROUND - Payara FISH-642
+     * Force inProcess and JMSRAManaged to return true so that we don't blow away logging. This doesn't fix the other
+     * issues that occur during the boot of OpenMQ on a clustered instance that's using a loopback address which need
+     * addressing separately
+     * @param manual Whether to force manual configuration of logging to occur
+     */
     public static void setForceManuallyConfigureLogging(boolean manual) {
         forceManuallyConfigureLogging = manual;
     }
@@ -353,7 +362,12 @@ public class CommGlobals
                     // First thing we do after reading in configuration
                     // is to initialize the Logger
                     Logger l = getLogger();
+
                     if (forceManuallyConfigureLogging) {
+                        // WORKAROUND - Payara FISH-642
+                        // Force inProcess and JMSRAManaged to return true so that we don't blow away logging
+                        // This doesn't fix the other issues that occur during the boot of OpenMQ on a clustered
+                        // instance that's using a loopback address which need addressing separately
                         l.configure(config, IMQ,
                                 true, true,
                                 (isNucleusManagedBroker() ? habitat:null));

--- a/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/comm/CommGlobals.java
+++ b/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/comm/CommGlobals.java
@@ -36,6 +36,8 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
+ *
+ * Portions Copyright 2020 Payara Foundation and/or its affiliates.
  */
 
 /*

--- a/mq/main/mq-broker/broker-core/pom.xml
+++ b/mq/main/mq-broker/broker-core/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
@@ -1179,6 +1179,10 @@ public class Broker implements GlobalErrorHandler, CommBroker {
                        Globals.getBrokerResources().getString(
                        BrokerResources.M_CLUSTER_SERVICE_FEATURE)));
         } else {
+            // WORKAROUND - Payara FISH-642
+            // Check whether we should force inProcess and JMSRAManaged to return true so that we don't blow away
+            // logging if an exception occurs during initialisation of the ClusterBroadcast - the logic of falling
+            // back to a non-clustered broker is flawed
             boolean forceManuallyConfigureLogging = Globals.getCommBroker().isInProcessBroker() &&
                     Globals.isJMSRAManagedSpecified();
             try {
@@ -1229,7 +1233,12 @@ public class Broker implements GlobalErrorHandler, CommBroker {
                 }
                 logger.log(Logger.WARNING, BrokerResources.I_USING_NOCLUSTER);
 
+                // WORKAROUND - Payara FISH-642
+                // Force inProcess and JMSRAManaged to return true so that we don't blow away logging.
+                // The logic here of falling back to a non-clustered broker doesn't work since we've already blown
+                // away all configuration by calling Broker.exit() before catching this exception.
                 Globals.setForceManuallyConfigureLogging(forceManuallyConfigureLogging);
+
                 mbus = new com.sun.messaging.jmq.jmsserver.cluster.api.NoCluster();
                 NO_CLUSTER = true;
             } catch (Exception ex) {

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
@@ -1179,6 +1179,8 @@ public class Broker implements GlobalErrorHandler, CommBroker {
                        Globals.getBrokerResources().getString(
                        BrokerResources.M_CLUSTER_SERVICE_FEATURE)));
         } else {
+            boolean forceManuallyConfigureLogging = Globals.getCommBroker().isInProcessBroker() &&
+                    Globals.isJMSRAManagedSpecified();
             try {
                 String cname =  "com.sun.messaging.jmq.jmsserver"
                                  + ".multibroker.ClusterBroadcaster";
@@ -1227,6 +1229,7 @@ public class Broker implements GlobalErrorHandler, CommBroker {
                 }
                 logger.log(Logger.WARNING, BrokerResources.I_USING_NOCLUSTER);
 
+                Globals.setForceManuallyConfigureLogging(forceManuallyConfigureLogging);
                 mbus = new com.sun.messaging.jmq.jmsserver.cluster.api.NoCluster();
                 NO_CLUSTER = true;
             } catch (Exception ex) {

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
@@ -36,6 +36,9 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
+ *
+ * Portions Copyright 2020 Payara Foundation and/or its affiliates.
+ *
  */
 
 /*

--- a/mq/main/mq-broker/cluster/pom.xml
+++ b/mq/main/mq-broker/cluster/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-api/pom.xml
+++ b/mq/main/mq-broker/partition/persist-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/partition/persist-jdbc/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/pom.xml
+++ b/mq/main/mq-broker/partition/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/persist-file/pom.xml
+++ b/mq/main/mq-broker/persist-file/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/persist-jdbc/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/jmsra-api/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>jmsra</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/jmsra-ra/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>jmsra</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/pom.xml
+++ b/mq/main/mq-jmsra/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/disk-io/pom.xml
+++ b/mq/main/persist/disk-io/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/disk-io/src/main/java/com/sun/messaging/jmq/io/disk/PHashMap.java
+++ b/mq/main/persist/disk-io/src/main/java/com/sun/messaging/jmq/io/disk/PHashMap.java
@@ -393,16 +393,10 @@ public class PHashMap extends ConcurrentHashMap {
 	return set;
     }
 
-    public Set keySet() {
-	checkLoaded();
+    public ConcurrentHashMap.KeySetView keySet() {
+		checkLoaded();
 
-	Set set = keySet;
-        if (set == null) {
-            keySet = new HashSet(super.keySet());
-            set = keySet;
-        }
-
-	return set;
+		return super.keySet();
     }
 
     public VRFileWarning getWarning() {

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/txnlog/pom.xml
+++ b/mq/main/persist/txnlog/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -54,7 +54,7 @@
     <groupId>org.glassfish.mq</groupId>
     <artifactId>mq</artifactId>
     <packaging>pom</packaging>
-    <version>5.1.1.final.payara-p4</version>
+    <version>5.1.1.final.payara-p5-SNAPSHOT</version>
     <name>MQ Main Project</name>
 
     <scm>

--- a/mq/main/portunif/pom.xml
+++ b/mq/main/portunif/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p5-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Also incorporates commits from https://github.com/payara/patched-src-openmq/pull/7

This is a part-fix / workaround.

Application logging breaks for clustered instances (as in Shoal/GMS clustered instances) due to OpenMQ blowing away logging configuration.

The cause of OpenMQ blowing it away is due to it running into an exception when starting the clustered broker, specifically that a loopback address is being used. Rather than exiting out at this point however, OpenMQ attempts to fallover to a non-clustered broker. This logic is currently flawed however due to the fact that the Broker which is being started gets "exited" before continuing to start using a non-clustered mbus - the broker doesn't exit due to being started in-process, and attempts to carry on despite having all configuration nulled, unsurprisingly running into NPEs (which you don't see because a side-effect of nulling the configuration is that it also blows away the logging configuration).

It should be pointed out that this flaw in OpenMQ exists regardless of this workaround / part-fix - the OpenMQ broker won't start regardless, but with this change you at least get _told_ it hasn't started. This change doesn't cause OpenMQ to print quite the same exception that it would normally however (if it could actually print the exception). It still gets the same NPEs caused by throwing away all configuration, but in a slightly different place, causing it to not get wrapped in a nicer "Illegal Loopback Address Used" message.