### PR TITLE
FISH-642 Alternative Fix

### DIFF
--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-api/pom.xml
+++ b/mq/main/bridge/bridge-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-api/pom.xml
+++ b/mq/main/bridge/bridge-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-jms/pom.xml
+++ b/mq/main/bridge/bridge-jms/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-jms/pom.xml
+++ b/mq/main/bridge/bridge-jms/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-stomp/pom.xml
+++ b/mq/main/bridge/bridge-stomp/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-stomp/pom.xml
+++ b/mq/main/bridge/bridge-stomp/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/comm-io/pom.xml
+++ b/mq/main/comm-io/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/comm-io/pom.xml
+++ b/mq/main/comm-io/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/comm-util/pom.xml
+++ b/mq/main/comm-util/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/comm-util/pom.xml
+++ b/mq/main/comm-util/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/copyright/pom.xml
+++ b/mq/main/copyright/pom.xml
@@ -48,7 +48,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.mq</groupId>
     <artifactId>copyright</artifactId>
-    <version>5.1.1.final.payara-p6</version>
+    <version>5.1.1.final.payara-p7-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>MQ copyright resources</name>
 

--- a/mq/main/copyright/pom.xml
+++ b/mq/main/copyright/pom.xml
@@ -48,7 +48,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.mq</groupId>
     <artifactId>copyright</artifactId>
-    <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+    <version>5.1.1.final.payara-p6</version>
     <packaging>jar</packaging>
     <name>MQ copyright resources</name>
 

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-server/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-server/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-share/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-share/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel/pom.xml
+++ b/mq/main/http-tunnel/tunnel/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel/pom.xml
+++ b/mq/main/http-tunnel/tunnel/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/jaxm-api/pom.xml
+++ b/mq/main/jaxm-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/jaxm-api/pom.xml
+++ b/mq/main/jaxm-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/logger/pom.xml
+++ b/mq/main/logger/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/logger/pom.xml
+++ b/mq/main/logger/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-cli/pom.xml
+++ b/mq/main/mq-admin/admin-cli/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-cli/pom.xml
+++ b/mq/main/mq-admin/admin-cli/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-gui/pom.xml
+++ b/mq/main/mq-admin/admin-gui/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-gui/pom.xml
+++ b/mq/main/mq-admin/admin-gui/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-comm/pom.xml
+++ b/mq/main/mq-broker/broker-comm/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-comm/pom.xml
+++ b/mq/main/mq-broker/broker-comm/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/comm/CommGlobals.java
+++ b/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/comm/CommGlobals.java
@@ -138,10 +138,6 @@ public class CommGlobals
 
     private static ServiceLocator habitat = null;
 
-    // WORKAROUND - Payara FISH-642
-    // Property that forces inProcess and JMSRAManaged to return true when initialising the logger
-    private static boolean forceManuallyConfigureLogging = false;
-
     public static void cleanupComm()
     {
         br = null;
@@ -163,7 +159,6 @@ public class CommGlobals
 
         commBroker = null;
         habitat = null;
-        forceManuallyConfigureLogging = false;
     }
 
     protected CommGlobals() {
@@ -312,17 +307,6 @@ public class CommGlobals
         commBroker = b;
     }
 
-    /**
-     * WORKAROUND - Payara FISH-642
-     * Force inProcess and JMSRAManaged to return true so that we don't blow away logging. This doesn't fix the other
-     * issues that occur during the boot of OpenMQ on a clustered instance that's using a loopback address which need
-     * addressing separately
-     * @param manual Whether to force manual configuration of logging to occur
-     */
-    public static void setForceManuallyConfigureLogging(boolean manual) {
-        forceManuallyConfigureLogging = manual;
-    }
-
     //------------------------------------------------------------------------
     //--               static methods for the singleton pattern             --
     //------------------------------------------------------------------------
@@ -364,21 +348,10 @@ public class CommGlobals
                     // First thing we do after reading in configuration
                     // is to initialize the Logger
                     Logger l = getLogger();
-
-                    if (forceManuallyConfigureLogging) {
-                        // WORKAROUND - Payara FISH-642
-                        // Force inProcess and JMSRAManaged to return true so that we don't blow away logging
-                        // This doesn't fix the other issues that occur during the boot of OpenMQ on a clustered
-                        // instance that's using a loopback address which need addressing separately
-                        l.configure(config, IMQ,
-                                true, true,
-                                (isNucleusManagedBroker() ? habitat:null));
-                    } else {
-                        l.configure(config, IMQ,
-                                (getCommBroker() == null ? false : getCommBroker().isInProcessBroker()),
-                                isJMSRAManagedSpecified(),
-                                (isNucleusManagedBroker() ? habitat:null));
-                    }
+                    l.configure(config, IMQ,
+                            (getCommBroker() == null ? false : getCommBroker().isInProcessBroker()),
+                            isJMSRAManagedSpecified(),
+                            (isNucleusManagedBroker() ? habitat : null));
                     
                     // LoggerManager will register as a config listener
                     // to handle dynamic updates to logger properties

--- a/mq/main/mq-broker/broker-core/pom.xml
+++ b/mq/main/mq-broker/broker-core/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-core/pom.xml
+++ b/mq/main/mq-broker/broker-core/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
@@ -222,6 +222,8 @@ public class Broker implements GlobalErrorHandler, CommBroker {
 
     private String haltLogString = "HALT";
 
+    private static boolean exited = false;
+
     public static boolean isInProcess() {
         return runningInProcess;
     }
@@ -336,12 +338,14 @@ public class Broker implements GlobalErrorHandler, CommBroker {
              bkrEvtListener.brokerEvent(event);
           	 setBrokerEventListener(null);
        }
+       exited = true;
     }
 
     private Broker() {
         Globals.setCommBroker(this);
         version = Globals.getVersion();
         rb = Globals.getBrokerResources();
+        exited = false;
     }
 
     Properties convertArgs(String args[]) 
@@ -1182,12 +1186,6 @@ public class Broker implements GlobalErrorHandler, CommBroker {
                        Globals.getBrokerResources().getString(
                        BrokerResources.M_CLUSTER_SERVICE_FEATURE)));
         } else {
-            // WORKAROUND - Payara FISH-642
-            // Check whether we should force inProcess and JMSRAManaged to return true so that we don't blow away
-            // logging if an exception occurs during initialisation of the ClusterBroadcast - the logic of falling
-            // back to a non-clustered broker is flawed
-            boolean forceManuallyConfigureLogging = Globals.getCommBroker().isInProcessBroker() &&
-                    Globals.isJMSRAManagedSpecified();
             try {
                 String cname =  "com.sun.messaging.jmq.jmsserver"
                                  + ".multibroker.ClusterBroadcaster";
@@ -1233,14 +1231,20 @@ public class Broker implements GlobalErrorHandler, CommBroker {
                 if (!(ex instanceof LoopbackAddressException)) {
                     logger.logStack(Logger.INFO,
                     BrokerResources.X_INTERNAL_EXCEPTION, ex.getMessage(), ex);
+                } else {
+                    // WORKAROUND - Payara FISH-642
+                    // Check if we've already destroyed the broker before attempting to fall back to non-clustered
+                    // Can't touch Globals here since we may have already wiped the global config - touching it
+                    // will potentially blow away pre-existing root logging config
+                    if (exited) {
+                        logger.log(Logger.ERROR, ex.getMessage());
+                        if (failStartThrowable != null) {
+                            failStartThrowable.initCause(new Exception(ex));
+                        }
+                        return (1);
+                    }
                 }
                 logger.log(Logger.WARNING, BrokerResources.I_USING_NOCLUSTER);
-
-                // WORKAROUND - Payara FISH-642
-                // Force inProcess and JMSRAManaged to return true so that we don't blow away logging.
-                // The logic here of falling back to a non-clustered broker doesn't work since we've already blown
-                // away all configuration by calling Broker.exit() before catching this exception.
-                Globals.setForceManuallyConfigureLogging(forceManuallyConfigureLogging);
 
                 mbus = new com.sun.messaging.jmq.jmsserver.cluster.api.NoCluster();
                 NO_CLUSTER = true;

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
@@ -1241,7 +1241,7 @@ public class Broker implements GlobalErrorHandler, CommBroker {
                         if (failStartThrowable != null) {
                             failStartThrowable.initCause(new Exception(ex));
                         }
-                        return (1);
+                        return 1;
                     }
                 }
                 logger.log(Logger.WARNING, BrokerResources.I_USING_NOCLUSTER);

--- a/mq/main/mq-broker/cluster/pom.xml
+++ b/mq/main/mq-broker/cluster/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/cluster/pom.xml
+++ b/mq/main/mq-broker/cluster/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-api/pom.xml
+++ b/mq/main/mq-broker/partition/persist-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-api/pom.xml
+++ b/mq/main/mq-broker/partition/persist-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/partition/persist-jdbc/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/partition/persist-jdbc/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/pom.xml
+++ b/mq/main/mq-broker/partition/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/pom.xml
+++ b/mq/main/mq-broker/partition/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/persist-file/pom.xml
+++ b/mq/main/mq-broker/persist-file/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/persist-file/pom.xml
+++ b/mq/main/mq-broker/persist-file/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/persist-jdbc/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/persist-jdbc/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/jmsra-api/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>jmsra</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/jmsra-api/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>jmsra</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/jmsra-ra/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>jmsra</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/jmsra-ra/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>jmsra</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/pom.xml
+++ b/mq/main/mq-jmsra/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/pom.xml
+++ b/mq/main/mq-jmsra/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/disk-io/pom.xml
+++ b/mq/main/persist/disk-io/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/disk-io/pom.xml
+++ b/mq/main/persist/disk-io/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/txnlog/pom.xml
+++ b/mq/main/persist/txnlog/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/txnlog/pom.xml
+++ b/mq/main/persist/txnlog/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -54,7 +54,7 @@
     <groupId>org.glassfish.mq</groupId>
     <artifactId>mq</artifactId>
     <packaging>pom</packaging>
-    <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+    <version>5.1.1.final.payara-p6</version>
     <name>MQ Main Project</name>
 
     <scm>

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -54,7 +54,7 @@
     <groupId>org.glassfish.mq</groupId>
     <artifactId>mq</artifactId>
     <packaging>pom</packaging>
-    <version>5.1.1.final.payara-p6</version>
+    <version>5.1.1.final.payara-p7-SNAPSHOT</version>
     <name>MQ Main Project</name>
 
     <scm>

--- a/mq/main/portunif/pom.xml
+++ b/mq/main/portunif/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6-SNAPSHOT</version>
+       <version>5.1.1.final.payara-p6</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/portunif/pom.xml
+++ b/mq/main/portunif/pom.xml
@@ -48,7 +48,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.1.final.payara-p6</version>
+       <version>5.1.1.final.payara-p7-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Alternative fix to https://github.com/payara/patched-src-openmq/pull/8

Incorporates commits from https://github.com/payara/patched-src-openmq/pull/9

Rather than forcing logging to not be blown away, leading to NPEs later down the line, just set a "stop I'm already dead" flag and exit, leading to much nicer errors.