### PR TITLE
FISH-6077 Upgrade Jakarta Messaging 3.1.0

### DIFF
--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>mq-distribution</artifactId>
-    <version>6.1.0.payara-p2</version>
+    <version>6.1.0.payara-p3</version>
     <packaging>pom</packaging>
     <name>Message Queue</name>
 

--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqbridge-admin</artifactId>

--- a/mq/main/bridge/bridge-api/pom.xml
+++ b/mq/main/bridge/bridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqbridge-api</artifactId>

--- a/mq/main/bridge/bridge-jms/pom.xml
+++ b/mq/main/bridge/bridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqbridge-jms</artifactId>

--- a/mq/main/bridge/bridge-stomp/pom.xml
+++ b/mq/main/bridge/bridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqbridge-stomp</artifactId>

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/comm-io/pom.xml
+++ b/mq/main/comm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqcomm-io</artifactId>

--- a/mq/main/comm-util/pom.xml
+++ b/mq/main/comm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqcomm-util</artifactId>

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>http-tunnel</artifactId>

--- a/mq/main/http-tunnel/tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-server</artifactId>

--- a/mq/main/http-tunnel/tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-share</artifactId>

--- a/mq/main/http-tunnel/tunnel/pom.xml
+++ b/mq/main/http-tunnel/tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqhttp-tunnel</artifactId>

--- a/mq/main/jaxm-api/pom.xml
+++ b/mq/main/jaxm-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqjaxm-api</artifactId>

--- a/mq/main/logger/pom.xml
+++ b/mq/main/logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-logger</artifactId>

--- a/mq/main/mq-admin/admin-cli/pom.xml
+++ b/mq/main/mq-admin/admin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqadmin-cli</artifactId>

--- a/mq/main/mq-admin/admin-gui/pom.xml
+++ b/mq/main/mq-admin/admin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqadmin-gui</artifactId>

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-admin</artifactId>

--- a/mq/main/mq-broker/broker-comm/pom.xml
+++ b/mq/main/mq-broker/broker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqbroker-comm</artifactId>

--- a/mq/main/mq-broker/broker-core/pom.xml
+++ b/mq/main/mq-broker/broker-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/cluster/pom.xml
+++ b/mq/main/mq-broker/cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-cluster</artifactId>

--- a/mq/main/mq-broker/partition/persist-api/pom.xml
+++ b/mq/main/mq-broker/partition/persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqpartition-persist-api</artifactId>

--- a/mq/main/mq-broker/partition/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/partition/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqpartition-persist-jdbc</artifactId>

--- a/mq/main/mq-broker/partition/pom.xml
+++ b/mq/main/mq-broker/partition/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/persist-file/pom.xml
+++ b/mq/main/mq-broker/persist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqpersist-file</artifactId>

--- a/mq/main/mq-broker/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqpersist-jdbc</artifactId>

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-client</artifactId>

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-direct</artifactId>

--- a/mq/main/mq-jmsra/jmsra-api/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqjmsra-api</artifactId>

--- a/mq/main/mq-jmsra/jmsra-ra/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/mq-jmsra/pom.xml
+++ b/mq/main/mq-jmsra/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>jmsra</artifactId>

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-share</artifactId>

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-ums</artifactId>

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqjmx-api</artifactId>

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/persist/disk-io/pom.xml
+++ b/mq/main/persist/disk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mqdisk-io</artifactId>

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>persist</artifactId>

--- a/mq/main/persist/txnlog/pom.xml
+++ b/mq/main/persist/txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-txnlog</artifactId>

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mq</artifactId>

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -78,7 +78,7 @@
 
         <!-- Versions of dependencies -->
         <hk2.version>3.0.1</hk2.version>
-        <jakarta-jms.version>3.0.0</jakarta-jms.version>
+        <jakarta-jms.version>3.1.0</jakarta-jms.version>
         <hk2.plugin.version>3.0.1</hk2.plugin.version>
 
         <grizzly.version>3.0.0</grizzly.version>

--- a/mq/main/portunif/pom.xml
+++ b/mq/main/portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.1.0.payara-p2</version>
+        <version>6.1.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-portunif</artifactId>

--- a/mq/pom.xml
+++ b/mq/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>6.1.0.payara-p2</version>
+    <version>6.1.0.payara-p3</version>
     <packaging>pom</packaging>
 
     <name>MQ Parent Project</name>

--- a/mq/pom.xml
+++ b/mq/pom.xml
@@ -58,6 +58,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <repositories>
+        <!-- Temporal for Jakarta EE 10 development until the jar files are available on maven central -->
+        <repository>
+            <id>staged-jakarta-releases</id>
+            <url>https://jakarta.oss.sonatype.org/content/groups/staging/</url>
+        </repository>
+    </repositories>
+
     <build>
         <defaultGoal>install</defaultGoal>
         <plugins>


### PR DESCRIPTION
Updating the jakarta messaging to the latest version and also adding jakartaee staging repository to be able to use Jakarta EE 10 repository that is not yet available in maven repository.