### PR TITLE
FISH-9034 OpenMQ JDK issues

### DIFF
--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>mq-distribution</artifactId>
-    <version>5.1.4.payara-p5</version>
+    <version>5.1.4.payara-p6-SNAPSHOT</version>
     <name>Message Queue</name>
 
     <url>https://github.com/eclipse-ee4j/openmq</url>

--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>mq-distribution</artifactId>
-    <version>5.1.4.payara-p5-SNAPSHOT</version>
+    <version>5.1.4.payara-p5</version>
     <name>Message Queue</name>
 
     <url>https://github.com/eclipse-ee4j/openmq</url>

--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-api/pom.xml
+++ b/mq/main/bridge/bridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-api/pom.xml
+++ b/mq/main/bridge/bridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-jms/pom.xml
+++ b/mq/main/bridge/bridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>5.1.4.payara-p5</version>
+        <version>5.1.4.payara-p6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-jms/pom.xml
+++ b/mq/main/bridge/bridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>5.1.4.payara-p5-SNAPSHOT</version>
+        <version>5.1.4.payara-p5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-stomp/pom.xml
+++ b/mq/main/bridge/bridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>5.1.4.payara-p5</version>
+        <version>5.1.4.payara-p6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-stomp/pom.xml
+++ b/mq/main/bridge/bridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>5.1.4.payara-p5-SNAPSHOT</version>
+        <version>5.1.4.payara-p5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p5</version>
+        <version>5.1.4.payara-p6-SNAPSHOT</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p5-SNAPSHOT</version>
+        <version>5.1.4.payara-p5</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/comm-io/pom.xml
+++ b/mq/main/comm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p5-SNAPSHOT</version>
+        <version>5.1.4.payara-p5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/comm-io/pom.xml
+++ b/mq/main/comm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p5</version>
+        <version>5.1.4.payara-p6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/comm-util/pom.xml
+++ b/mq/main/comm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p5-SNAPSHOT</version>
+        <version>5.1.4.payara-p5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/comm-util/pom.xml
+++ b/mq/main/comm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p5</version>
+        <version>5.1.4.payara-p6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel/pom.xml
+++ b/mq/main/http-tunnel/tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel/pom.xml
+++ b/mq/main/http-tunnel/tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/jaxm-api/pom.xml
+++ b/mq/main/jaxm-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/jaxm-api/pom.xml
+++ b/mq/main/jaxm-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/logger/pom.xml
+++ b/mq/main/logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/logger/pom.xml
+++ b/mq/main/logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-cli/pom.xml
+++ b/mq/main/mq-admin/admin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-cli/pom.xml
+++ b/mq/main/mq-admin/admin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-gui/pom.xml
+++ b/mq/main/mq-admin/admin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-gui/pom.xml
+++ b/mq/main/mq-admin/admin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-comm/pom.xml
+++ b/mq/main/mq-broker/broker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-comm/pom.xml
+++ b/mq/main/mq-broker/broker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-core/pom.xml
+++ b/mq/main/mq-broker/broker-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>5.1.4.payara-p5-SNAPSHOT</version>
+        <version>5.1.4.payara-p5</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/broker-core/pom.xml
+++ b/mq/main/mq-broker/broker-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>5.1.4.payara-p5</version>
+        <version>5.1.4.payara-p6-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/cluster/pom.xml
+++ b/mq/main/mq-broker/cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/cluster/pom.xml
+++ b/mq/main/mq-broker/cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-api/pom.xml
+++ b/mq/main/mq-broker/partition/persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-api/pom.xml
+++ b/mq/main/mq-broker/partition/persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/partition/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/partition/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/pom.xml
+++ b/mq/main/mq-broker/partition/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>5.1.4.payara-p5-SNAPSHOT</version>
+        <version>5.1.4.payara-p5</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/partition/pom.xml
+++ b/mq/main/mq-broker/partition/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>5.1.4.payara-p5</version>
+        <version>5.1.4.payara-p6-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/persist-file/pom.xml
+++ b/mq/main/mq-broker/persist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/persist-file/pom.xml
+++ b/mq/main/mq-broker/persist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p5</version>
+        <version>5.1.4.payara-p6-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p5-SNAPSHOT</version>
+        <version>5.1.4.payara-p5</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/jmsra-api/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>5.1.4.payara-p5-SNAPSHOT</version>
+        <version>5.1.4.payara-p5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/jmsra-api/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>5.1.4.payara-p5</version>
+        <version>5.1.4.payara-p6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/jmsra-ra/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>5.1.4.payara-p5</version>
+        <version>5.1.4.payara-p6-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/mq-jmsra/jmsra-ra/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>5.1.4.payara-p5-SNAPSHOT</version>
+        <version>5.1.4.payara-p5</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/mq-jmsra/pom.xml
+++ b/mq/main/mq-jmsra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/pom.xml
+++ b/mq/main/mq-jmsra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p5</version>
+        <version>5.1.4.payara-p6-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p5-SNAPSHOT</version>
+        <version>5.1.4.payara-p5</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/persist/disk-io/pom.xml
+++ b/mq/main/persist/disk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/disk-io/pom.xml
+++ b/mq/main/persist/disk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/txnlog/pom.xml
+++ b/mq/main/persist/txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/txnlog/pom.xml
+++ b/mq/main/persist/txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>5.1.4.payara-p5-SNAPSHOT</version>
+        <version>5.1.4.payara-p5</version>
     </parent>
 
     <artifactId>mq</artifactId>

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>5.1.4.payara-p5</version>
+        <version>5.1.4.payara-p6-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq</artifactId>

--- a/mq/main/portunif/pom.xml
+++ b/mq/main/portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5</version>
+       <version>5.1.4.payara-p6-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/portunif/pom.xml
+++ b/mq/main/portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p5-SNAPSHOT</version>
+       <version>5.1.4.payara-p5</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/pom.xml
+++ b/mq/pom.xml
@@ -30,7 +30,7 @@
     <name>MQ Parent Project</name>
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>5.1.4.payara-p5</version>
+    <version>5.1.4.payara-p6-SNAPSHOT</version>
     <url>https://github.com/eclipse-ee4j/openmq</url>
 
     <scm>

--- a/mq/pom.xml
+++ b/mq/pom.xml
@@ -30,7 +30,7 @@
     <name>MQ Parent Project</name>
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>5.1.4.payara-p5-SNAPSHOT</version>
+    <version>5.1.4.payara-p5</version>
     <url>https://github.com/eclipse-ee4j/openmq</url>
 
     <scm>

--- a/mq/src/solaris/etc/imqinit.sh
+++ b/mq/src/solaris/etc/imqinit.sh
@@ -310,6 +310,9 @@ do
   fi
 done
 
+imq_javahome=${imq_javahome%\"}
+imq_javahome=${imq_javahome#\"}
+
 if [ -z "$imq_javahome" ]; then
    imq_javahome=`which java | grep java | sed -e "s/bin\/java//"`	
    if [ -z "$imq_javahome" ] ; then


### PR DESCRIPTION
The issue was caused by JDKs higher than 8 wrapping the JAVA_HOME parameter in "speech marks", which were then treated literally as part of the path in `$imq_javahome/bin/java`. This PR strips the enclosing marks.