### PR TITLE
FISH-11544 Reapply Applicable OpenMQ Patches

### DIFF
--- a/docs/mq-admin-guide/pom.xml
+++ b/docs/mq-admin-guide/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-admin-guide</artifactId>

--- a/docs/mq-admin-guide/pom.xml
+++ b/docs/mq-admin-guide/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-admin-guide</artifactId>

--- a/docs/mq-dev-guide-c/pom.xml
+++ b/docs/mq-dev-guide-c/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-dev-guide-c</artifactId>

--- a/docs/mq-dev-guide-c/pom.xml
+++ b/docs/mq-dev-guide-c/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-dev-guide-c</artifactId>

--- a/docs/mq-dev-guide-java/pom.xml
+++ b/docs/mq-dev-guide-java/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-dev-guide-java</artifactId>

--- a/docs/mq-dev-guide-java/pom.xml
+++ b/docs/mq-dev-guide-java/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-dev-guide-java</artifactId>

--- a/docs/mq-dev-guide-jmx/pom.xml
+++ b/docs/mq-dev-guide-jmx/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-dev-guide-jmx</artifactId>

--- a/docs/mq-dev-guide-jmx/pom.xml
+++ b/docs/mq-dev-guide-jmx/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-dev-guide-jmx</artifactId>

--- a/docs/mq-release-notes/pom.xml
+++ b/docs/mq-release-notes/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-release-notes</artifactId>

--- a/docs/mq-release-notes/pom.xml
+++ b/docs/mq-release-notes/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-release-notes</artifactId>

--- a/docs/mq-shared-doc-resources/pom.xml
+++ b/docs/mq-shared-doc-resources/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-shared-doc-resources</artifactId>

--- a/docs/mq-shared-doc-resources/pom.xml
+++ b/docs/mq-shared-doc-resources/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-shared-doc-resources</artifactId>

--- a/docs/mq-tech-over/pom.xml
+++ b/docs/mq-tech-over/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-tech-over</artifactId>

--- a/docs/mq-tech-over/pom.xml
+++ b/docs/mq-tech-over/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-tech-over</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-docs</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-docs</artifactId>

--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-admin</artifactId>

--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqbridge-admin</artifactId>

--- a/mq/main/bridge/bridge-api/pom.xml
+++ b/mq/main/bridge/bridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqbridge-api</artifactId>

--- a/mq/main/bridge/bridge-api/pom.xml
+++ b/mq/main/bridge/bridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-api</artifactId>

--- a/mq/main/bridge/bridge-jms/pom.xml
+++ b/mq/main/bridge/bridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqbridge-jms</artifactId>

--- a/mq/main/bridge/bridge-jms/pom.xml
+++ b/mq/main/bridge/bridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-jms</artifactId>

--- a/mq/main/bridge/bridge-stomp/pom.xml
+++ b/mq/main/bridge/bridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqbridge-stomp</artifactId>

--- a/mq/main/bridge/bridge-stomp/pom.xml
+++ b/mq/main/bridge/bridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-stomp</artifactId>

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/comm-io/pom.xml
+++ b/mq/main/comm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqcomm-io</artifactId>

--- a/mq/main/comm-io/pom.xml
+++ b/mq/main/comm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqcomm-io</artifactId>

--- a/mq/main/comm-util/pom.xml
+++ b/mq/main/comm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqcomm-util</artifactId>

--- a/mq/main/comm-util/pom.xml
+++ b/mq/main/comm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqcomm-util</artifactId>

--- a/mq/main/helpfiles/pom.xml
+++ b/mq/main/helpfiles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>helpfiles</artifactId>

--- a/mq/main/helpfiles/pom.xml
+++ b/mq/main/helpfiles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>helpfiles</artifactId>

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>http-tunnel</artifactId>

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>http-tunnel</artifactId>

--- a/mq/main/http-tunnel/tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-server</artifactId>

--- a/mq/main/http-tunnel/tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-server</artifactId>

--- a/mq/main/http-tunnel/tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-share</artifactId>

--- a/mq/main/http-tunnel/tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-share</artifactId>

--- a/mq/main/http-tunnel/tunnel/pom.xml
+++ b/mq/main/http-tunnel/tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqhttp-tunnel</artifactId>

--- a/mq/main/http-tunnel/tunnel/pom.xml
+++ b/mq/main/http-tunnel/tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel</artifactId>

--- a/mq/main/logger/pom.xml
+++ b/mq/main/logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-logger</artifactId>

--- a/mq/main/logger/pom.xml
+++ b/mq/main/logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-logger</artifactId>

--- a/mq/main/mq-admin/admin-cli/pom.xml
+++ b/mq/main/mq-admin/admin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqadmin-cli</artifactId>

--- a/mq/main/mq-admin/admin-cli/pom.xml
+++ b/mq/main/mq-admin/admin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqadmin-cli</artifactId>

--- a/mq/main/mq-admin/admin-gui/pom.xml
+++ b/mq/main/mq-admin/admin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqadmin-gui</artifactId>

--- a/mq/main/mq-admin/admin-gui/pom.xml
+++ b/mq/main/mq-admin/admin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqadmin-gui</artifactId>

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-admin</artifactId>

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-admin</artifactId>

--- a/mq/main/mq-broker/broker-comm/pom.xml
+++ b/mq/main/mq-broker/broker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbroker-comm</artifactId>

--- a/mq/main/mq-broker/broker-comm/pom.xml
+++ b/mq/main/mq-broker/broker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqbroker-comm</artifactId>

--- a/mq/main/mq-broker/broker-core/pom.xml
+++ b/mq/main/mq-broker/broker-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/broker-core/pom.xml
+++ b/mq/main/mq-broker/broker-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
@@ -993,7 +993,7 @@ public class Broker implements GlobalErrorHandler, CommBroker {
                             if (failStartThrowable != null) {
                                 failStartThrowable.initCause(new Exception(ex));
                             }
-                            return (1);
+                            return 1;
                         }
                     }
                     logger.log(Logger.WARNING, BrokerResources.I_USING_NOCLUSTER);

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
@@ -136,6 +136,8 @@ public class Broker implements GlobalErrorHandler, CommBroker {
 
     private String haltLogString = "HALT";
 
+    private static boolean exited = false;
+
     public static boolean isInProcess() {
         return runningInProcess;
     }
@@ -246,12 +248,14 @@ public class Broker implements GlobalErrorHandler, CommBroker {
             bkrEvtListener.brokerEvent(event);
             setBrokerEventListener(null);
         }
+       exited = true;
     }
 
     private Broker() {
         Globals.setCommBroker(this);
         version = Globals.getVersion();
         rb = Globals.getBrokerResources();
+        exited = false;
     }
 
     /**
@@ -979,6 +983,18 @@ public class Broker implements GlobalErrorHandler, CommBroker {
                     }
                     if (!(ex instanceof LoopbackAddressException)) {
                         logger.logStack(Logger.INFO, BrokerResources.X_INTERNAL_EXCEPTION, ex.getMessage(), ex);
+                    } else {
+                        // WORKAROUND - Payara FISH-642
+                        // Check if we've already destroyed the broker before attempting to fall back to non-clustered
+                        // Can't touch Globals here since we may have already wiped the global config - touching it
+                        // will potentially blow away pre-existing root logging config
+                        if (exited) {
+                            logger.log(Logger.ERROR, ex.getMessage());
+                            if (failStartThrowable != null) {
+                                failStartThrowable.initCause(new Exception(ex));
+                            }
+                            return (1);
+                        }
                     }
                     logger.log(Logger.WARNING, BrokerResources.I_USING_NOCLUSTER);
 

--- a/mq/main/mq-broker/cluster/pom.xml
+++ b/mq/main/mq-broker/cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-cluster</artifactId>

--- a/mq/main/mq-broker/cluster/pom.xml
+++ b/mq/main/mq-broker/cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-cluster</artifactId>

--- a/mq/main/mq-broker/partition/persist-api/pom.xml
+++ b/mq/main/mq-broker/partition/persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqpartition-persist-api</artifactId>

--- a/mq/main/mq-broker/partition/persist-api/pom.xml
+++ b/mq/main/mq-broker/partition/persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpartition-persist-api</artifactId>

--- a/mq/main/mq-broker/partition/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/partition/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqpartition-persist-jdbc</artifactId>

--- a/mq/main/mq-broker/partition/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/partition/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpartition-persist-jdbc</artifactId>

--- a/mq/main/mq-broker/partition/pom.xml
+++ b/mq/main/mq-broker/partition/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/partition/pom.xml
+++ b/mq/main/mq-broker/partition/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/persist-file/pom.xml
+++ b/mq/main/mq-broker/persist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqpersist-file</artifactId>

--- a/mq/main/mq-broker/persist-file/pom.xml
+++ b/mq/main/mq-broker/persist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpersist-file</artifactId>

--- a/mq/main/mq-broker/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqpersist-jdbc</artifactId>

--- a/mq/main/mq-broker/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpersist-jdbc</artifactId>

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-client</artifactId>

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-client</artifactId>

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-direct</artifactId>

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-direct</artifactId>

--- a/mq/main/mq-jmsra/jmsra-api/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmsra-api</artifactId>

--- a/mq/main/mq-jmsra/jmsra-api/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqjmsra-api</artifactId>

--- a/mq/main/mq-jmsra/jmsra-ra/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/mq-jmsra/jmsra-ra/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/ra/EndpointConsumer.java
+++ b/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/ra/EndpointConsumer.java
@@ -482,24 +482,6 @@ public class EndpointConsumer implements jakarta.jms.ExceptionListener, com.sun.
                     msgConsumer = xas.createDurableSubscriber((Topic) destination, aSpec.getSubscriptionName(), aSpec.getMessageSelector(), false);
                 } else {
                     msgConsumer = xas.createConsumer(destination, aSpec.getMessageSelector());
-                    // test to see if Queue is enabled for more than one consumer when InClustered true
-                    if (destination instanceof jakarta.jms.Queue && aSpec._isInClusteredContainerSet()) {
-                        // Fail activation if it is not
-                        try {
-                            msgConsumer2 = xas.createConsumer(destination, aSpec.getMessageSelector());
-                            msgConsumer2.close();
-                            msgConsumer2 = null;
-                        } catch (JMSException jmse) {
-                            try {
-                                xac.close();
-                            } catch (JMSException jmsecc) {
-                                // System.out.println("MQRA:EC:closed xac on conn creation exception-"+jmsecc.getMessage());
-                            }
-                            xac = null;
-
-                            throw new NotSupportedException("MQRA:EC:Error clustering multiple consumers on Queue:\n" + jmse.getMessage(), jmse);
-                        }
-                    }
                 }
             }
             msgListener = new MessageListener(this, this.endpointFactory, aSpec);

--- a/mq/main/mq-jmsra/pom.xml
+++ b/mq/main/mq-jmsra/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>jmsra</artifactId>

--- a/mq/main/mq-jmsra/pom.xml
+++ b/mq/main/mq-jmsra/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jmsra</artifactId>

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-share</artifactId>

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-share</artifactId>

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-ums</artifactId>

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-ums</artifactId>

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmx-api</artifactId>

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqjmx-api</artifactId>

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/persist/disk-io/pom.xml
+++ b/mq/main/persist/disk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqdisk-io</artifactId>

--- a/mq/main/persist/disk-io/pom.xml
+++ b/mq/main/persist/disk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mqdisk-io</artifactId>

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>persist</artifactId>

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>persist</artifactId>

--- a/mq/main/persist/txnlog/pom.xml
+++ b/mq/main/persist/txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-txnlog</artifactId>

--- a/mq/main/persist/txnlog/pom.xml
+++ b/mq/main/persist/txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-txnlog</artifactId>

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/main/portunif/pom.xml
+++ b/mq/main/portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1-SNAPSHOT</version>
+        <version>6.7.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-portunif</artifactId>

--- a/mq/main/portunif/pom.xml
+++ b/mq/main/portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.7.0.payara-p1</version>
+        <version>6.7.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-portunif</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>6.7.0.payara-p1</version>
+    <version>6.7.0.payara-p2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>MQ Parent Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>6.7.0.payara-p1-SNAPSHOT</version>
+    <version>6.7.0.payara-p1</version>
     <packaging>pom</packaging>
 
     <name>MQ Parent Project</name>


### PR DESCRIPTION
Cherry-picks the two applicable patches to OpenMQ 6.7.0.
The patch for FISH-28 has been synced to upstream so we don't need to cherry-pick it anymore.

FISH-642 can be reproduced.
FISH-7273 still being tested (complicated reproducer which doesn't like loopback or WSL).

OpenMQ, interestingly, seems to have just dropped support for running it in a non-embedded manner in Windows - all of the .exe files are gone despite the fact there's still code that looks for them e.g.

```
Cannot run program "C:\Users\pandr\Git\Payara\appserver\distributions\payara\target\stage\payara7\mq\bin\imqbrokersvc.exe": CreateProcess error=2, The system cannot find the file specified

...

public String[] makeStartProviderCmdLine(String iMQHome, String optArgs[], String serverName, boolean argsOnly) throws IOException, JMSException {

        Vector v = new Vector();

        String append = null;
        if (!argsOnly) {
            String iMQBrokerPath;

            if (java.io.File.separator.equals("\\")) {
                // Windows path
                // <iMQHome>\\imqbrokersvc.exe -console
                *********iMQBrokerPath = iMQHome + java.io.File.separator + "imqbrokersvc.exe";***********
                append = "-console";
            } else {
                // Unix path.
                // <iMQHome>/bin/imqbrokerd
                iMQBrokerPath = iMQHome + java.io.File.separator + "imqbrokerd";
            }
            v.add(iMQBrokerPath);
        }
        ...
```

Ran the unit tests and they seem to work fine.