### PR TITLE
FISH-13185 FISH-13298 Reapply Unsynced Patches and Close Streams

### DIFF
--- a/docs/mq-admin-guide/pom.xml
+++ b/docs/mq-admin-guide/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-admin-guide</artifactId>

--- a/docs/mq-admin-guide/pom.xml
+++ b/docs/mq-admin-guide/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-admin-guide</artifactId>

--- a/docs/mq-dev-guide-c/pom.xml
+++ b/docs/mq-dev-guide-c/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-dev-guide-c</artifactId>

--- a/docs/mq-dev-guide-c/pom.xml
+++ b/docs/mq-dev-guide-c/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-dev-guide-c</artifactId>

--- a/docs/mq-dev-guide-java/pom.xml
+++ b/docs/mq-dev-guide-java/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-dev-guide-java</artifactId>

--- a/docs/mq-dev-guide-java/pom.xml
+++ b/docs/mq-dev-guide-java/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-dev-guide-java</artifactId>

--- a/docs/mq-dev-guide-jmx/pom.xml
+++ b/docs/mq-dev-guide-jmx/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-dev-guide-jmx</artifactId>

--- a/docs/mq-dev-guide-jmx/pom.xml
+++ b/docs/mq-dev-guide-jmx/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-dev-guide-jmx</artifactId>

--- a/docs/mq-release-notes/pom.xml
+++ b/docs/mq-release-notes/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-release-notes</artifactId>

--- a/docs/mq-release-notes/pom.xml
+++ b/docs/mq-release-notes/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-release-notes</artifactId>

--- a/docs/mq-shared-doc-resources/pom.xml
+++ b/docs/mq-shared-doc-resources/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-shared-doc-resources</artifactId>

--- a/docs/mq-shared-doc-resources/pom.xml
+++ b/docs/mq-shared-doc-resources/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-shared-doc-resources</artifactId>

--- a/docs/mq-tech-over/pom.xml
+++ b/docs/mq-tech-over/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-tech-over</artifactId>

--- a/docs/mq-tech-over/pom.xml
+++ b/docs/mq-tech-over/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-tech-over</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-docs</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-docs</artifactId>

--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/main/bridge/mqbridge-admin/pom.xml
+++ b/mq/main/bridge/mqbridge-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-admin</artifactId>

--- a/mq/main/bridge/mqbridge-admin/pom.xml
+++ b/mq/main/bridge/mqbridge-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqbridge-admin</artifactId>

--- a/mq/main/bridge/mqbridge-api/pom.xml
+++ b/mq/main/bridge/mqbridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqbridge-api</artifactId>

--- a/mq/main/bridge/mqbridge-api/pom.xml
+++ b/mq/main/bridge/mqbridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-api</artifactId>

--- a/mq/main/bridge/mqbridge-jms/pom.xml
+++ b/mq/main/bridge/mqbridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-jms</artifactId>

--- a/mq/main/bridge/mqbridge-jms/pom.xml
+++ b/mq/main/bridge/mqbridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqbridge-jms</artifactId>

--- a/mq/main/bridge/mqbridge-stomp/pom.xml
+++ b/mq/main/bridge/mqbridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqbridge-stomp</artifactId>

--- a/mq/main/bridge/mqbridge-stomp/pom.xml
+++ b/mq/main/bridge/mqbridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-stomp</artifactId>

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/helpfiles/pom.xml
+++ b/mq/main/helpfiles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>helpfiles</artifactId>

--- a/mq/main/helpfiles/pom.xml
+++ b/mq/main/helpfiles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>helpfiles</artifactId>

--- a/mq/main/http-tunnel/mqhttp-tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/mqhttp-tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-server</artifactId>

--- a/mq/main/http-tunnel/mqhttp-tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/mqhttp-tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-server</artifactId>

--- a/mq/main/http-tunnel/mqhttp-tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/mqhttp-tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-share</artifactId>

--- a/mq/main/http-tunnel/mqhttp-tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/mqhttp-tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-share</artifactId>

--- a/mq/main/http-tunnel/mqhttp-tunnel/pom.xml
+++ b/mq/main/http-tunnel/mqhttp-tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqhttp-tunnel</artifactId>

--- a/mq/main/http-tunnel/mqhttp-tunnel/pom.xml
+++ b/mq/main/http-tunnel/mqhttp-tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel</artifactId>

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>http-tunnel</artifactId>

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>http-tunnel</artifactId>

--- a/mq/main/jmsra/mqjmsra-api/pom.xml
+++ b/mq/main/jmsra/mqjmsra-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqjmsra-api</artifactId>

--- a/mq/main/jmsra/mqjmsra-api/pom.xml
+++ b/mq/main/jmsra/mqjmsra-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmsra-api</artifactId>

--- a/mq/main/jmsra/mqjmsra-ra/pom.xml
+++ b/mq/main/jmsra/mqjmsra-ra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/jmsra/mqjmsra-ra/pom.xml
+++ b/mq/main/jmsra/mqjmsra-ra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/jmsra/mqjmsra-ra/src/main/java/com/sun/messaging/jms/ra/EndpointConsumer.java
+++ b/mq/main/jmsra/mqjmsra-ra/src/main/java/com/sun/messaging/jms/ra/EndpointConsumer.java
@@ -482,24 +482,6 @@ public class EndpointConsumer implements jakarta.jms.ExceptionListener, com.sun.
                     msgConsumer = xas.createDurableSubscriber((Topic) destination, aSpec.getSubscriptionName(), aSpec.getMessageSelector(), false);
                 } else {
                     msgConsumer = xas.createConsumer(destination, aSpec.getMessageSelector());
-                    // test to see if Queue is enabled for more than one consumer when InClustered true
-                    if (destination instanceof jakarta.jms.Queue && aSpec._isInClusteredContainerSet()) {
-                        // Fail activation if it is not
-                        try {
-                            msgConsumer2 = xas.createConsumer(destination, aSpec.getMessageSelector());
-                            msgConsumer2.close();
-                            msgConsumer2 = null;
-                        } catch (JMSException jmse) {
-                            try {
-                                xac.close();
-                            } catch (JMSException jmsecc) {
-                                // System.out.println("MQRA:EC:closed xac on conn creation exception-"+jmsecc.getMessage());
-                            }
-                            xac = null;
-
-                            throw new NotSupportedException("MQRA:EC:Error clustering multiple consumers on Queue:\n" + jmse.getMessage(), jmse);
-                        }
-                    }
                 }
             }
             msgListener = new MessageListener(this, this.endpointFactory, aSpec);

--- a/mq/main/jmsra/pom.xml
+++ b/mq/main/jmsra/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>jmsra</artifactId>

--- a/mq/main/jmsra/pom.xml
+++ b/mq/main/jmsra/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jmsra</artifactId>

--- a/mq/main/mq-admin/mqadmin-cli/pom.xml
+++ b/mq/main/mq-admin/mqadmin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqadmin-cli</artifactId>

--- a/mq/main/mq-admin/mqadmin-cli/pom.xml
+++ b/mq/main/mq-admin/mqadmin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqadmin-cli</artifactId>

--- a/mq/main/mq-admin/mqadmin-gui/pom.xml
+++ b/mq/main/mq-admin/mqadmin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqadmin-gui</artifactId>

--- a/mq/main/mq-admin/mqadmin-gui/pom.xml
+++ b/mq/main/mq-admin/mqadmin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqadmin-gui</artifactId>

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-admin</artifactId>

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-admin</artifactId>

--- a/mq/main/mq-broker/mq-cluster/pom.xml
+++ b/mq/main/mq-broker/mq-cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-cluster</artifactId>

--- a/mq/main/mq-broker/mq-cluster/pom.xml
+++ b/mq/main/mq-broker/mq-cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-cluster</artifactId>

--- a/mq/main/mq-broker/mq-partition/mqpartition-persist-api/pom.xml
+++ b/mq/main/mq-broker/mq-partition/mqpartition-persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpartition-persist-api</artifactId>

--- a/mq/main/mq-broker/mq-partition/mqpartition-persist-api/pom.xml
+++ b/mq/main/mq-broker/mq-partition/mqpartition-persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqpartition-persist-api</artifactId>

--- a/mq/main/mq-broker/mq-partition/mqpartition-persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/mq-partition/mqpartition-persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqpartition-persist-jdbc</artifactId>

--- a/mq/main/mq-broker/mq-partition/mqpartition-persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/mq-partition/mqpartition-persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpartition-persist-jdbc</artifactId>

--- a/mq/main/mq-broker/mq-partition/pom.xml
+++ b/mq/main/mq-broker/mq-partition/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/mq-partition/pom.xml
+++ b/mq/main/mq-broker/mq-partition/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/mqbroker-comm/pom.xml
+++ b/mq/main/mq-broker/mqbroker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqbroker-comm</artifactId>

--- a/mq/main/mq-broker/mqbroker-comm/pom.xml
+++ b/mq/main/mq-broker/mqbroker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbroker-comm</artifactId>

--- a/mq/main/mq-broker/mqbroker-core/pom.xml
+++ b/mq/main/mq-broker/mqbroker-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/mqbroker-core/pom.xml
+++ b/mq/main/mq-broker/mqbroker-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/mqbroker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
+++ b/mq/main/mq-broker/mqbroker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java
@@ -136,6 +136,8 @@ public class Broker implements GlobalErrorHandler, CommBroker {
 
     private String haltLogString = "HALT";
 
+    private static boolean exited = false;
+
     public static boolean isInProcess() {
         return runningInProcess;
     }
@@ -246,12 +248,14 @@ public class Broker implements GlobalErrorHandler, CommBroker {
             bkrEvtListener.brokerEvent(event);
             setBrokerEventListener(null);
         }
+       exited = true;
     }
 
     private Broker() {
         Globals.setCommBroker(this);
         version = Globals.getVersion();
         rb = Globals.getBrokerResources();
+        exited = false;
     }
 
     /**
@@ -979,6 +983,18 @@ public class Broker implements GlobalErrorHandler, CommBroker {
                     }
                     if (!(ex instanceof LoopbackAddressException)) {
                         logger.logStack(Logger.INFO, BrokerResources.X_INTERNAL_EXCEPTION, ex.getMessage(), ex);
+                    } else {
+                        // WORKAROUND - Payara FISH-642
+                        // Check if we've already destroyed the broker before attempting to fall back to non-clustered
+                        // Can't touch Globals here since we may have already wiped the global config - touching it
+                        // will potentially blow away pre-existing root logging config
+                        if (exited) {
+                            logger.log(Logger.ERROR, ex.getMessage());
+                            if (failStartThrowable != null) {
+                                failStartThrowable.initCause(new Exception(ex));
+                            }
+                            return 1;
+                        }
                     }
                     logger.log(Logger.WARNING, BrokerResources.I_USING_NOCLUSTER);
 

--- a/mq/main/mq-broker/mqpersist-file/pom.xml
+++ b/mq/main/mq-broker/mqpersist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqpersist-file</artifactId>

--- a/mq/main/mq-broker/mqpersist-file/pom.xml
+++ b/mq/main/mq-broker/mqpersist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpersist-file</artifactId>

--- a/mq/main/mq-broker/mqpersist-jdbc/pom.xml
+++ b/mq/main/mq-broker/mqpersist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpersist-jdbc</artifactId>

--- a/mq/main/mq-broker/mqpersist-jdbc/pom.xml
+++ b/mq/main/mq-broker/mqpersist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqpersist-jdbc</artifactId>

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-client</artifactId>

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-client</artifactId>

--- a/mq/main/mq-client/src/main/java/com/sun/messaging/AdministeredObject.java
+++ b/mq/main/mq-client/src/main/java/com/sun/messaging/AdministeredObject.java
@@ -182,11 +182,10 @@ public abstract class AdministeredObject implements java.io.Serializable {
         Properties[] configurations = cachedConfigurationMap.get(defaultsBase);
         if (configurations == null) {
             // not in cache
-            try {
-                // Attempt to initialize the configuration from property files
-                InputStream is1 = getClass().getResourceAsStream(defaultsBase + AO_DEFAULTS + AO_PROP_EXT);
-                InputStream is2 = getClass().getResourceAsStream(defaultsBase + AO_TYPES + AO_PROP_EXT);
-                InputStream is3 = getClass().getResourceAsStream(defaultsBase + AO_LABELS + AO_PROP_EXT);
+            // Attempt to initialize the configuration from property files
+            try (InputStream is1 = getClass().getResourceAsStream(defaultsBase + AO_DEFAULTS + AO_PROP_EXT);
+                    InputStream is2 = getClass().getResourceAsStream(defaultsBase + AO_TYPES + AO_PROP_EXT);
+                    InputStream is3 = getClass().getResourceAsStream(defaultsBase + AO_LABELS + AO_PROP_EXT)) {
                 if (is1 != null && is2 != null && is3 != null) {
                     configuration = new Properties();
                     configuration.load(is1);

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-direct</artifactId>

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-direct</artifactId>

--- a/mq/main/mq-logger/pom.xml
+++ b/mq/main/mq-logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-logger</artifactId>

--- a/mq/main/mq-logger/pom.xml
+++ b/mq/main/mq-logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-logger</artifactId>

--- a/mq/main/mq-packager-opensource/pom.xml
+++ b/mq/main/mq-packager-opensource/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/mq-packager-opensource/pom.xml
+++ b/mq/main/mq-packager-opensource/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/mq-portunif/pom.xml
+++ b/mq/main/mq-portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-portunif</artifactId>

--- a/mq/main/mq-portunif/pom.xml
+++ b/mq/main/mq-portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-portunif</artifactId>

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-share</artifactId>

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-share</artifactId>

--- a/mq/main/mq-share/src/main/java/com/sun/messaging/jmq/Version.java
+++ b/mq/main/mq-share/src/main/java/com/sun/messaging/jmq/Version.java
@@ -138,27 +138,28 @@ public class Version {
 
     public Version(boolean isJar) {
         this.isJar = isJar;
-        try {
-            InputStream is = getClass().getResourceAsStream(propname);
+        try (InputStream is = getClass().getResourceAsStream(propname)) {
             if (is == null) {
                 System.err.println(rb.getString(rb.E_VERSION_PROPS));
             }
             props = new Properties();
             props.load(is);
-
-            /*
-             * Load commercial version of property file if it exists. XXX might want to add version checks here prior to loading it.
-             */
-            is = getClass().getResourceAsStream(comm_propname);
-            if (is != null) {
-                props.load(is);
-            }
-
         } catch (Exception ex) {
             System.err.println(rb.getString(rb.E_VERSION_LOAD));
             ex.printStackTrace();
         }
 
+        /*
+         * Load commercial version of property file if it exists. XXX might want to add version checks here prior to loading it.
+         */
+        try (InputStream is = getClass().getResourceAsStream(comm_propname)) {
+            if (is != null) {
+                props.load(is);
+            }
+        } catch (Exception ex) {
+            System.err.println(rb.getString(rb.E_VERSION_LOAD));
+            ex.printStackTrace();
+        }
     }
 
     /**

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-ums</artifactId>

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-ums</artifactId>

--- a/mq/main/mqcomm-io/pom.xml
+++ b/mq/main/mqcomm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqcomm-io</artifactId>

--- a/mq/main/mqcomm-io/pom.xml
+++ b/mq/main/mqcomm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqcomm-io</artifactId>

--- a/mq/main/mqcomm-util/pom.xml
+++ b/mq/main/mqcomm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqcomm-util</artifactId>

--- a/mq/main/mqcomm-util/pom.xml
+++ b/mq/main/mqcomm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqcomm-util</artifactId>

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqjmx-api</artifactId>

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmx-api</artifactId>

--- a/mq/main/persist/mq-txnlog/pom.xml
+++ b/mq/main/persist/mq-txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mq-txnlog</artifactId>

--- a/mq/main/persist/mq-txnlog/pom.xml
+++ b/mq/main/persist/mq-txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-txnlog</artifactId>

--- a/mq/main/persist/mqdisk-io/pom.xml
+++ b/mq/main/persist/mqdisk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>mqdisk-io</artifactId>

--- a/mq/main/persist/mqdisk-io/pom.xml
+++ b/mq/main/persist/mqdisk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqdisk-io</artifactId>

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>persist</artifactId>

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
     </parent>
 
     <artifactId>persist</artifactId>

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.8.0.payara-p1-SNAPSHOT</version>
+        <version>6.8.0.payara-p1</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.8.0.payara-p1</version>
+        <version>6.8.0.payara-p2-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>6.8.0.payara-p1-SNAPSHOT</version>
+    <version>6.8.0.payara-p1</version>
     <packaging>pom</packaging>
 
     <name>MQ Parent Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>6.8.0.payara-p1</version>
+    <version>6.8.0.payara-p2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>MQ Parent Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     </mailingLists>
 
     <modules>
-        <module>docs</module>
+<!--        <module>docs</module>-->
         <module>mq/main</module>
         <module>mq/distribution</module>
     </modules>


### PR DESCRIPTION
Uses try-with-resources to help close streams which are opened and potentially never closed.

Also includes https://github.com/payara/patched-src-openmq/pull/32
The only two commits that are a part of FISH-13185 are the last two: dda861cf9656043a8799df22eb769969fb40ce3c and e86e7095c07608548823b6a991482a9db242394b

Passed unit tests, and when used in Payara Server the warning messages about unclosed streams no longer get printed