### PR TITLE
FISH-13096 : restrict imq.cluster.url to file scheme and block remote updates [6.5.1]

### DIFF
--- a/docs/mq-admin-guide/pom.xml
+++ b/docs/mq-admin-guide/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
     <artifactId>mq-admin-guide</artifactId>
     <packaging>pom</packaging>

--- a/docs/mq-admin-guide/pom.xml
+++ b/docs/mq-admin-guide/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
     <artifactId>mq-admin-guide</artifactId>
     <packaging>pom</packaging>

--- a/docs/mq-dev-guide-c/pom.xml
+++ b/docs/mq-dev-guide-c/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
     <artifactId>mq-dev-guide-c</artifactId>
     <packaging>pom</packaging>

--- a/docs/mq-dev-guide-c/pom.xml
+++ b/docs/mq-dev-guide-c/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
     <artifactId>mq-dev-guide-c</artifactId>
     <packaging>pom</packaging>

--- a/docs/mq-dev-guide-java/pom.xml
+++ b/docs/mq-dev-guide-java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
     <artifactId>mq-dev-guide-java</artifactId>
     <packaging>pom</packaging>

--- a/docs/mq-dev-guide-java/pom.xml
+++ b/docs/mq-dev-guide-java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
     <artifactId>mq-dev-guide-java</artifactId>
     <packaging>pom</packaging>

--- a/docs/mq-dev-guide-jmx/pom.xml
+++ b/docs/mq-dev-guide-jmx/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
     <artifactId>mq-dev-guide-jmx</artifactId>
     <packaging>pom</packaging>

--- a/docs/mq-dev-guide-jmx/pom.xml
+++ b/docs/mq-dev-guide-jmx/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
     <artifactId>mq-dev-guide-jmx</artifactId>
     <packaging>pom</packaging>

--- a/docs/mq-release-notes/pom.xml
+++ b/docs/mq-release-notes/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
     <artifactId>mq-release-notes</artifactId>
     <packaging>pom</packaging>

--- a/docs/mq-release-notes/pom.xml
+++ b/docs/mq-release-notes/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
     <artifactId>mq-release-notes</artifactId>
     <packaging>pom</packaging>

--- a/docs/mq-tech-over/pom.xml
+++ b/docs/mq-tech-over/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
     <artifactId>mq-tech-over</artifactId>
     <packaging>pom</packaging>

--- a/docs/mq-tech-over/pom.xml
+++ b/docs/mq-tech-over/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
     <artifactId>mq-tech-over</artifactId>
     <packaging>pom</packaging>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
     <artifactId>mq-docs</artifactId>
     <packaging>pom</packaging>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
     <artifactId>mq-docs</artifactId>
     <packaging>pom</packaging>

--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>mq-distribution</artifactId>
-    <version>6.5.1.payara-p3</version>
+    <version>6.5.1.payara-p4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Message Queue</name>
 

--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>mq-distribution</artifactId>
-    <version>6.5.1.payara-p3-SNAPSHOT</version>
+    <version>6.5.1.payara-p3</version>
     <packaging>pom</packaging>
     <name>Message Queue</name>
 

--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqbridge-admin</artifactId>

--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-admin</artifactId>

--- a/mq/main/bridge/bridge-api/pom.xml
+++ b/mq/main/bridge/bridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqbridge-api</artifactId>

--- a/mq/main/bridge/bridge-api/pom.xml
+++ b/mq/main/bridge/bridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-api</artifactId>

--- a/mq/main/bridge/bridge-jms/pom.xml
+++ b/mq/main/bridge/bridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-jms</artifactId>

--- a/mq/main/bridge/bridge-jms/pom.xml
+++ b/mq/main/bridge/bridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqbridge-jms</artifactId>

--- a/mq/main/bridge/bridge-stomp/pom.xml
+++ b/mq/main/bridge/bridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-stomp</artifactId>

--- a/mq/main/bridge/bridge-stomp/pom.xml
+++ b/mq/main/bridge/bridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqbridge-stomp</artifactId>

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/comm-io/pom.xml
+++ b/mq/main/comm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqcomm-io</artifactId>

--- a/mq/main/comm-io/pom.xml
+++ b/mq/main/comm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqcomm-io</artifactId>

--- a/mq/main/comm-util/pom.xml
+++ b/mq/main/comm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqcomm-util</artifactId>

--- a/mq/main/comm-util/pom.xml
+++ b/mq/main/comm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqcomm-util</artifactId>

--- a/mq/main/helpfiles/pom.xml
+++ b/mq/main/helpfiles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>helpfiles</artifactId>

--- a/mq/main/helpfiles/pom.xml
+++ b/mq/main/helpfiles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>helpfiles</artifactId>

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>http-tunnel</artifactId>

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>http-tunnel</artifactId>

--- a/mq/main/http-tunnel/tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-server</artifactId>

--- a/mq/main/http-tunnel/tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-server</artifactId>

--- a/mq/main/http-tunnel/tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-share</artifactId>

--- a/mq/main/http-tunnel/tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-share</artifactId>

--- a/mq/main/http-tunnel/tunnel/pom.xml
+++ b/mq/main/http-tunnel/tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel</artifactId>

--- a/mq/main/http-tunnel/tunnel/pom.xml
+++ b/mq/main/http-tunnel/tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqhttp-tunnel</artifactId>

--- a/mq/main/logger/pom.xml
+++ b/mq/main/logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mq-logger</artifactId>

--- a/mq/main/logger/pom.xml
+++ b/mq/main/logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-logger</artifactId>

--- a/mq/main/mq-admin/admin-cli/pom.xml
+++ b/mq/main/mq-admin/admin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqadmin-cli</artifactId>

--- a/mq/main/mq-admin/admin-cli/pom.xml
+++ b/mq/main/mq-admin/admin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqadmin-cli</artifactId>

--- a/mq/main/mq-admin/admin-gui/pom.xml
+++ b/mq/main/mq-admin/admin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqadmin-gui</artifactId>

--- a/mq/main/mq-admin/admin-gui/pom.xml
+++ b/mq/main/mq-admin/admin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqadmin-gui</artifactId>

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mq-admin</artifactId>

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-admin</artifactId>

--- a/mq/main/mq-broker/broker-comm/pom.xml
+++ b/mq/main/mq-broker/broker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqbroker-comm</artifactId>

--- a/mq/main/mq-broker/broker-comm/pom.xml
+++ b/mq/main/mq-broker/broker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbroker-comm</artifactId>

--- a/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/config/FileConfigStore.java
+++ b/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/config/FileConfigStore.java
@@ -42,6 +42,14 @@ public class FileConfigStore implements ConfigStore {
     private static final String cluster_prop = CommGlobals.IMQ + ".cluster.url";
 
     /**
+     * Only file-system URLs are accepted for {@code imq.cluster.url}. Allowing
+     * arbitrary schemes (http, https, ftp, jar, ...) at this sink would let an
+     * attacker who can set the property turn the broker into an SSRF gadget on
+     * every restart. See CVE-2026-24457.
+     */
+    static final String ALLOWED_CLUSTER_URL_SCHEME = "file";
+
+    /**
      * path to the actual location of the instance property file
      */
     private String storedprop_loc = null;
@@ -141,6 +149,13 @@ public class FileConfigStore implements ConfigStore {
 
         try {
             URL curl = new URL(cluster_url_str);
+            if (!isAllowedClusterUrl(curl)) {
+                logger.log(Logger.WARNING,
+                        "Refusing to load " + cluster_prop + "='" + cluster_url_str
+                                + "': scheme '" + curl.getProtocol() + "' is not permitted; only '"
+                                + ALLOWED_CLUSTER_URL_SCHEME + "' is allowed (CVE-2026-24457)");
+                return storedprops;
+            }
             try (InputStream cu_is = curl.openStream()) {
                 try (BufferedInputStream bfile = new BufferedInputStream(cu_is)) {
                     storedprops.load(bfile);
@@ -150,6 +165,20 @@ public class FileConfigStore implements ConfigStore {
             logger.log(Logger.WARNING, BrokerResources.W_BAD_PROPERTY_FILE, "cluster", cluster_url_str, ex);
         }
         return storedprops;
+    }
+
+    /**
+     * @return {@code true} only when the URL uses the {@code file} scheme.
+     *     Anything else (http, https, ftp, jar, gopher, ...) would let an
+     *     attacker exfiltrate data or probe internal endpoints when the
+     *     broker loads cluster properties on startup.
+     */
+    static boolean isAllowedClusterUrl(URL url) {
+        if (url == null) {
+            return false;
+        }
+        String scheme = url.getProtocol();
+        return scheme != null && ALLOWED_CLUSTER_URL_SCHEME.equalsIgnoreCase(scheme);
     }
 
     /**

--- a/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/config/FileConfigStore.java
+++ b/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/config/FileConfigStore.java
@@ -42,10 +42,14 @@ public class FileConfigStore implements ConfigStore {
     private static final String cluster_prop = CommGlobals.IMQ + ".cluster.url";
 
     /**
-     * Only file-system URLs are accepted for {@code imq.cluster.url}. Allowing
-     * arbitrary schemes (http, https, ftp, jar, ...) at this sink would let an
-     * attacker who can set the property turn the broker into an SSRF gadget on
-     * every restart. See CVE-2026-24457.
+     * The {@code imq.cluster.url} property is intended to point at a cluster
+     * properties file on a local or shared filesystem, so we restrict it to
+     * the {@code file} scheme. Any other scheme that {@link java.net.URL#openStream()}
+     * understands (http, https, ftp, jar, ...) would expose the broker to
+     * SSRF, arbitrary file read, and -- depending on the JVM -- remote class
+     * loading on every restart. CVE-2026-24457 describes the underlying
+     * vulnerability but does not prescribe a specific scheme allow-list;
+     * {@code file} is the minimal set that preserves the intended use.
      */
     static final String ALLOWED_CLUSTER_URL_SCHEME = "file";
 

--- a/mq/main/mq-broker/broker-comm/src/test/java/com/sun/messaging/jmq/jmsserver/config/FileConfigStore_isAllowedClusterUrl_Test.java
+++ b/mq/main/mq-broker/broker-comm/src/test/java/com/sun/messaging/jmq/jmsserver/config/FileConfigStore_isAllowedClusterUrl_Test.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.messaging.jmq.jmsserver.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FileConfigStore_isAllowedClusterUrl_Test {
+
+    @Test
+    void shouldRejectNullUrl() {
+        assertThat(FileConfigStore.isAllowedClusterUrl(null)).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "file:/tmp/cluster.properties",
+            "file:///etc/openmq/cluster.properties",
+            "FILE:///tmp/cluster.properties",
+    })
+    void shouldAcceptFileUrl(String spec) throws Exception {
+        @SuppressWarnings("deprecation")
+        URL url = new URL(spec);
+        assertThat(FileConfigStore.isAllowedClusterUrl(url)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://attacker.example/exfil",
+            "https://attacker.example/exfil",
+            "ftp://attacker.example/payload",
+            "jar:file:/tmp/x.jar!/cluster.properties",
+    })
+    void shouldRejectNonFileUrl(String spec) throws Exception {
+        @SuppressWarnings("deprecation")
+        URL url = new URL(spec);
+        assertThat(FileConfigStore.isAllowedClusterUrl(url))
+                .as("CVE-2026-24457: only file:// is permitted for imq.cluster.url")
+                .isFalse();
+    }
+}

--- a/mq/main/mq-broker/broker-core/pom.xml
+++ b/mq/main/mq-broker/broker-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/broker-core/pom.xml
+++ b/mq/main/mq-broker/broker-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/data/handlers/admin/UpdateBrokerPropsHandler.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/data/handlers/admin/UpdateBrokerPropsHandler.java
@@ -16,9 +16,12 @@
 
 package com.sun.messaging.jmq.jmsserver.data.handlers.admin;
 
+import java.util.Collections;
 import java.util.Hashtable;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
 
 import com.sun.messaging.jmq.jmsserver.cluster.api.ha.HAMonitorService;
 import com.sun.messaging.jmq.jmsserver.service.imq.IMQConnection;
@@ -31,8 +34,39 @@ import com.sun.messaging.jmq.jmsserver.config.*;
 public class UpdateBrokerPropsHandler extends AdminCmdHandler {
     private static boolean DEBUG = getDEBUG();
 
+    /**
+     * Properties that an authenticated admin client is not allowed to set
+     * over the wire. {@code imq.cluster.url} is denied because the broker
+     * passes the value to {@link java.net.URL#openStream()} on startup, which
+     * an attacker could abuse for arbitrary file read or SSRF (CVE-2026-24457).
+     * These properties must be configured locally in {@code config.properties}
+     * by an operator with filesystem access to the broker host.
+     */
+    static final Set<String> REMOTE_UPDATE_DENYLIST;
+    static {
+        Set<String> denied = new TreeSet<>();
+        denied.add("imq.cluster.url");
+        REMOTE_UPDATE_DENYLIST = Collections.unmodifiableSet(denied);
+    }
+
     public UpdateBrokerPropsHandler(AdminDataHandler parent) {
         super(parent);
+    }
+
+    /**
+     * @return the first denied property name found in {@code props}, or
+     *     {@code null} if every property is permitted for remote update.
+     */
+    static String findDeniedProperty(Properties props) {
+        if (props == null) {
+            return null;
+        }
+        for (String name : props.stringPropertyNames()) {
+            if (REMOTE_UPDATE_DENYLIST.contains(name)) {
+                return name;
+            }
+        }
+        return null;
     }
 
     /**
@@ -63,6 +97,20 @@ public class UpdateBrokerPropsHandler extends AdminCmdHandler {
             // Get properties we are to update from message body
             Properties p = (Properties) getBodyObject(cmd_msg);
             logger.log(Logger.INFO, rb.I_UPDATE_BROKER_PROPS, "[" + p + "]");
+
+            String denied = findDeniedProperty(p);
+            if (denied != null) {
+                status = Status.BAD_REQUEST;
+                msg = "Property '" + denied + "' cannot be modified via the admin protocol; "
+                        + "set it locally in config.properties (CVE-2026-24457)";
+                logger.log(Logger.WARNING, msg);
+
+                Packet reply = new Packet(con.useDirectBuffers());
+                reply.setPacketType(PacketType.OBJECT_MESSAGE);
+                setProperties(reply, MessageType.UPDATE_BROKER_PROPS_REPLY, status, msg);
+                parent.sendReply(con, cmd_msg, reply);
+                return true;
+            }
 
             // Update the broker configuration
             BrokerConfig bcfg = Globals.getConfig();

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/ClusterConfig.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/ClusterConfig.java
@@ -477,6 +477,20 @@ public class ClusterConfig extends MQMBeanReadWrite implements ConfigListener {
 
     @Override
     public void validate(String name, String value) throws PropertyUpdateException {
+        if ("imq.cluster.url".equals(name) && value != null && !value.isEmpty()) {
+            try {
+                @SuppressWarnings("deprecation")
+                java.net.URL u = new java.net.URL(value);
+                if (!"file".equalsIgnoreCase(u.getProtocol())) {
+                    throw new PropertyUpdateException(
+                            "Property '" + name + "' only accepts file URLs; '"
+                                    + u.getProtocol() + "' is not permitted (CVE-2026-24457)");
+                }
+            } catch (java.net.MalformedURLException e) {
+                throw new PropertyUpdateException(
+                        "Property '" + name + "' value is not a valid URL: " + value, e);
+            }
+        }
     }
 
     @Override

--- a/mq/main/mq-broker/broker-core/src/test/java/com/sun/messaging/jmq/jmsserver/data/handlers/admin/UpdateBrokerPropsHandler_findDeniedProperty_Test.java
+++ b/mq/main/mq-broker/broker-core/src/test/java/com/sun/messaging/jmq/jmsserver/data/handlers/admin/UpdateBrokerPropsHandler_findDeniedProperty_Test.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.messaging.jmq.jmsserver.data.handlers.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+class UpdateBrokerPropsHandler_findDeniedProperty_Test {
+
+    @Test
+    void shouldReturnNullForNullProperties() {
+        assertThat(UpdateBrokerPropsHandler.findDeniedProperty(null)).isNull();
+    }
+
+    @Test
+    void shouldReturnNullForEmptyProperties() {
+        assertThat(UpdateBrokerPropsHandler.findDeniedProperty(new Properties())).isNull();
+    }
+
+    @Test
+    void shouldAllowUnrelatedProperty() {
+        Properties p = new Properties();
+        p.setProperty("imq.autocreate.queue", "true");
+        p.setProperty("imq.log.level", "INFO");
+
+        assertThat(UpdateBrokerPropsHandler.findDeniedProperty(p)).isNull();
+    }
+
+    @Test
+    void shouldRejectClusterUrl() {
+        Properties p = new Properties();
+        p.setProperty("imq.cluster.url", "file:///etc/passwd");
+
+        assertThat(UpdateBrokerPropsHandler.findDeniedProperty(p)).isEqualTo("imq.cluster.url");
+    }
+
+    @Test
+    void shouldRejectClusterUrlEvenWhenMixedWithAllowedProperties() {
+        Properties p = new Properties();
+        p.setProperty("imq.log.level", "DEBUG");
+        p.setProperty("imq.cluster.url", "http://attacker.example/exfil");
+        p.setProperty("imq.autocreate.queue", "false");
+
+        assertThat(UpdateBrokerPropsHandler.findDeniedProperty(p)).isEqualTo("imq.cluster.url");
+    }
+}

--- a/mq/main/mq-broker/cluster/pom.xml
+++ b/mq/main/mq-broker/cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-cluster</artifactId>

--- a/mq/main/mq-broker/cluster/pom.xml
+++ b/mq/main/mq-broker/cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mq-cluster</artifactId>

--- a/mq/main/mq-broker/partition/persist-api/pom.xml
+++ b/mq/main/mq-broker/partition/persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqpartition-persist-api</artifactId>

--- a/mq/main/mq-broker/partition/persist-api/pom.xml
+++ b/mq/main/mq-broker/partition/persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpartition-persist-api</artifactId>

--- a/mq/main/mq-broker/partition/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/partition/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqpartition-persist-jdbc</artifactId>

--- a/mq/main/mq-broker/partition/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/partition/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpartition-persist-jdbc</artifactId>

--- a/mq/main/mq-broker/partition/pom.xml
+++ b/mq/main/mq-broker/partition/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/partition/pom.xml
+++ b/mq/main/mq-broker/partition/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/persist-file/pom.xml
+++ b/mq/main/mq-broker/persist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpersist-file</artifactId>

--- a/mq/main/mq-broker/persist-file/pom.xml
+++ b/mq/main/mq-broker/persist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqpersist-file</artifactId>

--- a/mq/main/mq-broker/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpersist-jdbc</artifactId>

--- a/mq/main/mq-broker/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqpersist-jdbc</artifactId>

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mq-client</artifactId>

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-client</artifactId>

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-direct</artifactId>

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mq-direct</artifactId>

--- a/mq/main/mq-jmsra/jmsra-api/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmsra-api</artifactId>

--- a/mq/main/mq-jmsra/jmsra-api/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqjmsra-api</artifactId>

--- a/mq/main/mq-jmsra/jmsra-ra/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/mq-jmsra/jmsra-ra/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/mq-jmsra/pom.xml
+++ b/mq/main/mq-jmsra/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>jmsra</artifactId>

--- a/mq/main/mq-jmsra/pom.xml
+++ b/mq/main/mq-jmsra/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>jmsra</artifactId>

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-share</artifactId>

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mq-share</artifactId>

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mq-ums</artifactId>

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-ums</artifactId>

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmx-api</artifactId>

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqjmx-api</artifactId>

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/persist/disk-io/pom.xml
+++ b/mq/main/persist/disk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mqdisk-io</artifactId>

--- a/mq/main/persist/disk-io/pom.xml
+++ b/mq/main/persist/disk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqdisk-io</artifactId>

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>persist</artifactId>

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>persist</artifactId>

--- a/mq/main/persist/txnlog/pom.xml
+++ b/mq/main/persist/txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-txnlog</artifactId>

--- a/mq/main/persist/txnlog/pom.xml
+++ b/mq/main/persist/txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mq-txnlog</artifactId>

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/main/portunif/pom.xml
+++ b/mq/main/portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3-SNAPSHOT</version>
+        <version>6.5.1.payara-p3</version>
     </parent>
 
     <artifactId>mq-portunif</artifactId>

--- a/mq/main/portunif/pom.xml
+++ b/mq/main/portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.5.1.payara-p3</version>
+        <version>6.5.1.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-portunif</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>6.5.1.payara-p3</version>
+    <version>6.5.1.payara-p4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>MQ Parent Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>6.5.1.payara-p3-SNAPSHOT</version>
+    <version>6.5.1.payara-p3</version>
     <packaging>pom</packaging>
 
     <name>MQ Parent Project</name>


### PR DESCRIPTION
Backport of #36 to `openmq-6.5.1.payara-maintenance`.

Payara Enterprise 6 PR: https://github.com/payara/Payara-Enterprise/pull/2764 (Tests passed)