### PR TITLE
FISH-13096 : restrict imq.cluster.url to file scheme and block remote updates [5.1.4]

### DIFF
--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>mq-distribution</artifactId>
-    <version>5.1.4.payara-p7</version>
+    <version>5.1.4.payara-p8-SNAPSHOT</version>
     <name>Message Queue</name>
 
     <url>https://github.com/eclipse-ee4j/openmq</url>

--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>mq-distribution</artifactId>
-    <version>5.1.4.payara-p7-SNAPSHOT</version>
+    <version>5.1.4.payara-p7</version>
     <name>Message Queue</name>
 
     <url>https://github.com/eclipse-ee4j/openmq</url>

--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-api/pom.xml
+++ b/mq/main/bridge/bridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-api/pom.xml
+++ b/mq/main/bridge/bridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>bridge</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-jms/pom.xml
+++ b/mq/main/bridge/bridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>5.1.4.payara-p7</version>
+        <version>5.1.4.payara-p8-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-jms/pom.xml
+++ b/mq/main/bridge/bridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>5.1.4.payara-p7-SNAPSHOT</version>
+        <version>5.1.4.payara-p7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-stomp/pom.xml
+++ b/mq/main/bridge/bridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>5.1.4.payara-p7</version>
+        <version>5.1.4.payara-p8-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/bridge-stomp/pom.xml
+++ b/mq/main/bridge/bridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>5.1.4.payara-p7-SNAPSHOT</version>
+        <version>5.1.4.payara-p7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p7</version>
+        <version>5.1.4.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p7-SNAPSHOT</version>
+        <version>5.1.4.payara-p7</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/comm-io/pom.xml
+++ b/mq/main/comm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p7</version>
+        <version>5.1.4.payara-p8-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/comm-io/pom.xml
+++ b/mq/main/comm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p7-SNAPSHOT</version>
+        <version>5.1.4.payara-p7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/comm-util/pom.xml
+++ b/mq/main/comm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p7</version>
+        <version>5.1.4.payara-p8-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/comm-util/pom.xml
+++ b/mq/main/comm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p7-SNAPSHOT</version>
+        <version>5.1.4.payara-p7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel/pom.xml
+++ b/mq/main/http-tunnel/tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/http-tunnel/tunnel/pom.xml
+++ b/mq/main/http-tunnel/tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>http-tunnel</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/jaxm-api/pom.xml
+++ b/mq/main/jaxm-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/jaxm-api/pom.xml
+++ b/mq/main/jaxm-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/logger/pom.xml
+++ b/mq/main/logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/logger/pom.xml
+++ b/mq/main/logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-cli/pom.xml
+++ b/mq/main/mq-admin/admin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-cli/pom.xml
+++ b/mq/main/mq-admin/admin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-gui/pom.xml
+++ b/mq/main/mq-admin/admin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/admin-gui/pom.xml
+++ b/mq/main/mq-admin/admin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-admin</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-comm/pom.xml
+++ b/mq/main/mq-broker/broker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-comm/pom.xml
+++ b/mq/main/mq-broker/broker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/config/FileConfigStore.java
+++ b/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/config/FileConfigStore.java
@@ -46,6 +46,14 @@ public class FileConfigStore implements ConfigStore {
     private static final String cluster_prop = CommGlobals.IMQ + ".cluster.url";
 
     /**
+     * Only file-system URLs are accepted for {@code imq.cluster.url}. Allowing
+     * arbitrary schemes (http, https, ftp, jar, ...) at this sink would let an
+     * attacker who can set the property turn the broker into an SSRF gadget on
+     * every restart. See CVE-2026-24457.
+     */
+    static final String ALLOWED_CLUSTER_URL_SCHEME = "file";
+
+    /**
      * path to the actual location of the instance property file
      */
     private String storedprop_loc = null;
@@ -147,6 +155,13 @@ public class FileConfigStore implements ConfigStore {
 
         try {
             URL curl = new URL(cluster_url_str);
+            if (!isAllowedClusterUrl(curl)) {
+                logger.log(Logger.WARNING,
+                        "Refusing to load " + cluster_prop + "='" + cluster_url_str
+                                + "': scheme '" + curl.getProtocol() + "' is not permitted; only '"
+                                + ALLOWED_CLUSTER_URL_SCHEME + "' is allowed (CVE-2026-24457)");
+                return storedprops;
+            }
             InputStream cu_is = curl.openStream();
             BufferedInputStream bfile = new BufferedInputStream(cu_is);
             storedprops.load(bfile);
@@ -156,6 +171,20 @@ public class FileConfigStore implements ConfigStore {
             logger.log(Logger.WARNING, BrokerResources.W_BAD_PROPERTY_FILE, "cluster", cluster_url_str, ex);
         }
         return storedprops;
+    }
+
+    /**
+     * @return {@code true} only when the URL uses the {@code file} scheme.
+     *     Anything else (http, https, ftp, jar, gopher, ...) would let an
+     *     attacker exfiltrate data or probe internal endpoints when the
+     *     broker loads cluster properties on startup.
+     */
+    static boolean isAllowedClusterUrl(URL url) {
+        if (url == null) {
+            return false;
+        }
+        String scheme = url.getProtocol();
+        return scheme != null && ALLOWED_CLUSTER_URL_SCHEME.equalsIgnoreCase(scheme);
     }
 
     /**

--- a/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/config/FileConfigStore.java
+++ b/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/config/FileConfigStore.java
@@ -46,10 +46,14 @@ public class FileConfigStore implements ConfigStore {
     private static final String cluster_prop = CommGlobals.IMQ + ".cluster.url";
 
     /**
-     * Only file-system URLs are accepted for {@code imq.cluster.url}. Allowing
-     * arbitrary schemes (http, https, ftp, jar, ...) at this sink would let an
-     * attacker who can set the property turn the broker into an SSRF gadget on
-     * every restart. See CVE-2026-24457.
+     * The {@code imq.cluster.url} property is intended to point at a cluster
+     * properties file on a local or shared filesystem, so we restrict it to
+     * the {@code file} scheme. Any other scheme that {@link java.net.URL#openStream()}
+     * understands (http, https, ftp, jar, ...) would expose the broker to
+     * SSRF, arbitrary file read, and -- depending on the JVM -- remote class
+     * loading on every restart. CVE-2026-24457 describes the underlying
+     * vulnerability but does not prescribe a specific scheme allow-list;
+     * {@code file} is the minimal set that preserves the intended use.
      */
     static final String ALLOWED_CLUSTER_URL_SCHEME = "file";
 

--- a/mq/main/mq-broker/broker-core/pom.xml
+++ b/mq/main/mq-broker/broker-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>5.1.4.payara-p7-SNAPSHOT</version>
+        <version>5.1.4.payara-p7</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/broker-core/pom.xml
+++ b/mq/main/mq-broker/broker-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>5.1.4.payara-p7</version>
+        <version>5.1.4.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/data/handlers/admin/UpdateBrokerPropsHandler.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/data/handlers/admin/UpdateBrokerPropsHandler.java
@@ -20,9 +20,12 @@
 
 package com.sun.messaging.jmq.jmsserver.data.handlers.admin;
 
+import java.util.Collections;
 import java.util.Hashtable;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
 
 import com.sun.messaging.jmq.io.Packet;
 import com.sun.messaging.jmq.jmsserver.cluster.api.ha.HAMonitorService;
@@ -36,8 +39,39 @@ import com.sun.messaging.jmq.jmsserver.config.*;
 public class UpdateBrokerPropsHandler extends AdminCmdHandler {
     private static boolean DEBUG = getDEBUG();
 
+    /**
+     * Properties that an authenticated admin client is not allowed to set
+     * over the wire. {@code imq.cluster.url} is denied because the broker
+     * passes the value to {@link java.net.URL#openStream()} on startup, which
+     * an attacker could abuse for arbitrary file read or SSRF (CVE-2026-24457).
+     * These properties must be configured locally in {@code config.properties}
+     * by an operator with filesystem access to the broker host.
+     */
+    static final Set<String> REMOTE_UPDATE_DENYLIST;
+    static {
+        Set<String> denied = new TreeSet<>();
+        denied.add("imq.cluster.url");
+        REMOTE_UPDATE_DENYLIST = Collections.unmodifiableSet(denied);
+    }
+
     public UpdateBrokerPropsHandler(AdminDataHandler parent) {
         super(parent);
+    }
+
+    /**
+     * @return the first denied property name found in {@code props}, or
+     *     {@code null} if every property is permitted for remote update.
+     */
+    static String findDeniedProperty(Properties props) {
+        if (props == null) {
+            return null;
+        }
+        for (String name : props.stringPropertyNames()) {
+            if (REMOTE_UPDATE_DENYLIST.contains(name)) {
+                return name;
+            }
+        }
+        return null;
     }
 
     /**
@@ -68,6 +102,20 @@ public class UpdateBrokerPropsHandler extends AdminCmdHandler {
             // Get properties we are to update from message body
             Properties p = (Properties) getBodyObject(cmd_msg);
             logger.log(Logger.INFO, rb.I_UPDATE_BROKER_PROPS, "[" + p + "]");
+
+            String denied = findDeniedProperty(p);
+            if (denied != null) {
+                status = Status.BAD_REQUEST;
+                msg = "Property '" + denied + "' cannot be modified via the admin protocol; "
+                        + "set it locally in config.properties (CVE-2026-24457)";
+                logger.log(Logger.WARNING, msg);
+
+                Packet reply = new Packet(con.useDirectBuffers());
+                reply.setPacketType(PacketType.OBJECT_MESSAGE);
+                setProperties(reply, MessageType.UPDATE_BROKER_PROPS_REPLY, status, msg);
+                parent.sendReply(con, cmd_msg, reply);
+                return true;
+            }
 
             // Update the broker configuration
             BrokerConfig bcfg = Globals.getConfig();

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/ClusterConfig.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/ClusterConfig.java
@@ -481,6 +481,22 @@ public class ClusterConfig extends MQMBeanReadWrite implements ConfigListener {
 
     @Override
     public void validate(String name, String value) throws PropertyUpdateException {
+        if ("imq.cluster.url".equals(name) && value != null && !value.isEmpty()) {
+            try {
+                @SuppressWarnings("deprecation")
+                java.net.URL u = new java.net.URL(value);
+                if (!"file".equalsIgnoreCase(u.getProtocol())) {
+                    throw new PropertyUpdateException(
+                            "Property '" + name + "' only accepts file URLs; '"
+                                    + u.getProtocol() + "' is not permitted (CVE-2026-24457)");
+                }
+            } catch (java.net.MalformedURLException e) {
+                PropertyUpdateException pe = new PropertyUpdateException(
+                        "Property '" + name + "' value is not a valid URL: " + value);
+                pe.initCause(e);
+                throw pe;
+            }
+        }
     }
 
     @Override

--- a/mq/main/mq-broker/cluster/pom.xml
+++ b/mq/main/mq-broker/cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/cluster/pom.xml
+++ b/mq/main/mq-broker/cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-api/pom.xml
+++ b/mq/main/mq-broker/partition/persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-api/pom.xml
+++ b/mq/main/mq-broker/partition/persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/partition/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/partition/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-partition</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/partition/pom.xml
+++ b/mq/main/mq-broker/partition/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>5.1.4.payara-p7</version>
+        <version>5.1.4.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/partition/pom.xml
+++ b/mq/main/mq-broker/partition/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>5.1.4.payara-p7-SNAPSHOT</version>
+        <version>5.1.4.payara-p7</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/persist-file/pom.xml
+++ b/mq/main/mq-broker/persist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/persist-file/pom.xml
+++ b/mq/main/mq-broker/persist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq-broker</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p7</version>
+        <version>5.1.4.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p7-SNAPSHOT</version>
+        <version>5.1.4.payara-p7</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/jmsra-api/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>5.1.4.payara-p7-SNAPSHOT</version>
+        <version>5.1.4.payara-p7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/jmsra-api/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>5.1.4.payara-p7</version>
+        <version>5.1.4.payara-p8-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/jmsra-ra/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>5.1.4.payara-p7</version>
+        <version>5.1.4.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/mq-jmsra/jmsra-ra/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>5.1.4.payara-p7-SNAPSHOT</version>
+        <version>5.1.4.payara-p7</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/mq-jmsra/pom.xml
+++ b/mq/main/mq-jmsra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-jmsra/pom.xml
+++ b/mq/main/mq-jmsra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p7</version>
+        <version>5.1.4.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>5.1.4.payara-p7-SNAPSHOT</version>
+        <version>5.1.4.payara-p7</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/persist/disk-io/pom.xml
+++ b/mq/main/persist/disk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/disk-io/pom.xml
+++ b/mq/main/persist/disk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/txnlog/pom.xml
+++ b/mq/main/persist/txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/persist/txnlog/pom.xml
+++ b/mq/main/persist/txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>persist</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>5.1.4.payara-p7-SNAPSHOT</version>
+        <version>5.1.4.payara-p7</version>
     </parent>
 
     <artifactId>mq</artifactId>

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>5.1.4.payara-p7</version>
+        <version>5.1.4.payara-p8-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq</artifactId>

--- a/mq/main/portunif/pom.xml
+++ b/mq/main/portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7-SNAPSHOT</version>
+       <version>5.1.4.payara-p7</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/main/portunif/pom.xml
+++ b/mq/main/portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.glassfish.mq</groupId>
        <artifactId>mq</artifactId>
-       <version>5.1.4.payara-p7</version>
+       <version>5.1.4.payara-p8-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mq/pom.xml
+++ b/mq/pom.xml
@@ -30,7 +30,7 @@
     <name>MQ Parent Project</name>
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>5.1.4.payara-p7</version>
+    <version>5.1.4.payara-p8-SNAPSHOT</version>
     <url>https://github.com/eclipse-ee4j/openmq</url>
 
     <scm>

--- a/mq/pom.xml
+++ b/mq/pom.xml
@@ -30,7 +30,7 @@
     <name>MQ Parent Project</name>
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>5.1.4.payara-p7-SNAPSHOT</version>
+    <version>5.1.4.payara-p7</version>
     <url>https://github.com/eclipse-ee4j/openmq</url>
 
     <scm>


### PR DESCRIPTION
Backport of #36 to `openmq-5.1.4.payara-maintenance`.

Payara Enterprise 5 PR: https://github.com/payara/Payara-Enterprise/pull/2763 (Tests passed)
Payara Enterprise 4 PR: https://github.com/payara/Payara-Enterprise/pull/2765 (Tests passed)