### PR TITLE
FISH-12426 Add Windows .bat launcher scripts and fix Windows broker launch in JMSAdminImpl

### DIFF
--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/main/bridge/mqbridge-admin/pom.xml
+++ b/mq/main/bridge/mqbridge-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-admin</artifactId>

--- a/mq/main/bridge/mqbridge-admin/pom.xml
+++ b/mq/main/bridge/mqbridge-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqbridge-admin</artifactId>

--- a/mq/main/bridge/mqbridge-api/pom.xml
+++ b/mq/main/bridge/mqbridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqbridge-api</artifactId>

--- a/mq/main/bridge/mqbridge-api/pom.xml
+++ b/mq/main/bridge/mqbridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-api</artifactId>

--- a/mq/main/bridge/mqbridge-jms/pom.xml
+++ b/mq/main/bridge/mqbridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-jms</artifactId>

--- a/mq/main/bridge/mqbridge-jms/pom.xml
+++ b/mq/main/bridge/mqbridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqbridge-jms</artifactId>

--- a/mq/main/bridge/mqbridge-stomp/pom.xml
+++ b/mq/main/bridge/mqbridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-stomp</artifactId>

--- a/mq/main/bridge/mqbridge-stomp/pom.xml
+++ b/mq/main/bridge/mqbridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqbridge-stomp</artifactId>

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/helpfiles/pom.xml
+++ b/mq/main/helpfiles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>helpfiles</artifactId>

--- a/mq/main/helpfiles/pom.xml
+++ b/mq/main/helpfiles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>helpfiles</artifactId>

--- a/mq/main/http-tunnel/mqhttp-tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/mqhttp-tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-server</artifactId>

--- a/mq/main/http-tunnel/mqhttp-tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/mqhttp-tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-server</artifactId>

--- a/mq/main/http-tunnel/mqhttp-tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/mqhttp-tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-share</artifactId>

--- a/mq/main/http-tunnel/mqhttp-tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/mqhttp-tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-share</artifactId>

--- a/mq/main/http-tunnel/mqhttp-tunnel/pom.xml
+++ b/mq/main/http-tunnel/mqhttp-tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqhttp-tunnel</artifactId>

--- a/mq/main/http-tunnel/mqhttp-tunnel/pom.xml
+++ b/mq/main/http-tunnel/mqhttp-tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel</artifactId>

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>http-tunnel</artifactId>

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>http-tunnel</artifactId>

--- a/mq/main/jmsra/mqjmsra-api/pom.xml
+++ b/mq/main/jmsra/mqjmsra-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqjmsra-api</artifactId>

--- a/mq/main/jmsra/mqjmsra-api/pom.xml
+++ b/mq/main/jmsra/mqjmsra-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmsra-api</artifactId>

--- a/mq/main/jmsra/mqjmsra-ra/pom.xml
+++ b/mq/main/jmsra/mqjmsra-ra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/jmsra/mqjmsra-ra/pom.xml
+++ b/mq/main/jmsra/mqjmsra-ra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/jmsra/pom.xml
+++ b/mq/main/jmsra/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>jmsra</artifactId>

--- a/mq/main/jmsra/pom.xml
+++ b/mq/main/jmsra/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>jmsra</artifactId>

--- a/mq/main/mq-admin/mqadmin-cli/pom.xml
+++ b/mq/main/mq-admin/mqadmin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqadmin-cli</artifactId>

--- a/mq/main/mq-admin/mqadmin-cli/pom.xml
+++ b/mq/main/mq-admin/mqadmin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqadmin-cli</artifactId>

--- a/mq/main/mq-admin/mqadmin-cli/src/main/java/com/sun/messaging/jmq/admin/jmsspi/JMSAdminImpl.java
+++ b/mq/main/mq-admin/mqadmin-cli/src/main/java/com/sun/messaging/jmq/admin/jmsspi/JMSAdminImpl.java
@@ -30,6 +30,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Vector;
@@ -624,7 +625,7 @@ public class JMSAdminImpl implements JMSAdmin, ExceptionListener {
         if (!argsOnly) {
             String iMQBrokerPath;
 
-            if (java.io.File.separator.equals("\\")) {
+            if (System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")) {
                 // Windows path - .bat files require cmd.exe /c to execute from Java
                 // <iMQHome>\imqbrokerd.bat
                 v.add("cmd.exe");
@@ -909,7 +910,7 @@ public class JMSAdminImpl implements JMSAdmin, ExceptionListener {
         int exitCode = 0;
         boolean interrupted = false;
 
-        if (java.io.File.separator.equals("\\")) {
+        if (System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")) {
             // Windows path - .bat files require cmd.exe /c to execute from Java
             // <mqBinDir>\imqbrokerd.bat
             iMQBrokerPath = mqBinDir + java.io.File.separator + "imqbrokerd.bat";
@@ -940,7 +941,7 @@ public class JMSAdminImpl implements JMSAdmin, ExceptionListener {
         //
 
         Vector v = new Vector();
-        if (java.io.File.separator.equals("\\")) {
+        if (System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")) {
             v.add("cmd.exe");
             v.add("/c");
         }
@@ -1022,7 +1023,7 @@ public class JMSAdminImpl implements JMSAdmin, ExceptionListener {
         int exitCode = 0;
         boolean interrupted = false;
 
-        if (java.io.File.separator.equals("\\")) {
+        if (System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")) {
             // Windows path - .bat files require cmd.exe /c to execute from Java
             // <mqBinDir>\imqbrokerd.bat
             iMQBrokerPath = mqBinDir + java.io.File.separator + "imqbrokerd.bat";
@@ -1053,7 +1054,7 @@ public class JMSAdminImpl implements JMSAdmin, ExceptionListener {
         //
 
         Vector v = new Vector();
-        if (java.io.File.separator.equals("\\")) {
+        if (System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")) {
             v.add("cmd.exe");
             v.add("/c");
         }

--- a/mq/main/mq-admin/mqadmin-cli/src/main/java/com/sun/messaging/jmq/admin/jmsspi/JMSAdminImpl.java
+++ b/mq/main/mq-admin/mqadmin-cli/src/main/java/com/sun/messaging/jmq/admin/jmsspi/JMSAdminImpl.java
@@ -621,15 +621,15 @@ public class JMSAdminImpl implements JMSAdmin, ExceptionListener {
 
         Vector v = new Vector();
 
-        String append = null;
         if (!argsOnly) {
             String iMQBrokerPath;
 
             if (java.io.File.separator.equals("\\")) {
-                // Windows path
-                // <iMQHome>\\imqbrokersvc.exe -console
-                iMQBrokerPath = iMQHome + java.io.File.separator + "imqbrokersvc.exe";
-                append = "-console";
+                // Windows path - .bat files require cmd.exe /c to execute from Java
+                // <iMQHome>\imqbrokerd.bat
+                v.add("cmd.exe");
+                v.add("/c");
+                iMQBrokerPath = iMQHome + java.io.File.separator + "imqbrokerd.bat";
             } else {
                 // Unix path.
                 // <iMQHome>/bin/imqbrokerd
@@ -666,10 +666,6 @@ public class JMSAdminImpl implements JMSAdmin, ExceptionListener {
         if (serverName != null) {
             v.add("-name");
             v.add(serverName);
-        }
-
-        if (append != null) {
-            v.add(append);
         }
 
         v.add("-port");
@@ -908,18 +904,15 @@ public class JMSAdminImpl implements JMSAdmin, ExceptionListener {
      * @exception JMSException thrown if the delete fails.
      */
     @Override
-    @SuppressWarnings({
-        "deprecation" // exec(java.lang.String) in java.lang.Runtime has been deprecated
-    })
     public void deleteProviderInstance(String mqBinDir, String optArgs, String serverName) throws IOException, JMSException {
         String iMQBrokerPath;
         int exitCode = 0;
         boolean interrupted = false;
 
         if (java.io.File.separator.equals("\\")) {
-            // Windows path
-            // <mqBinDir>\\bin\\imqbrokerd.exe
-            iMQBrokerPath = mqBinDir + java.io.File.separator + "imqbrokerd.exe";
+            // Windows path - .bat files require cmd.exe /c to execute from Java
+            // <mqBinDir>\imqbrokerd.bat
+            iMQBrokerPath = mqBinDir + java.io.File.separator + "imqbrokerd.bat";
         } else {
             // Unix path.
             // <mqBinDir>/bin/imqbrokerd
@@ -934,7 +927,7 @@ public class JMSAdminImpl implements JMSAdmin, ExceptionListener {
         // constraints -
         //
         // 1. The "-javahome" argument, if present, must be first.
-        // Otherwise it does not work on Windoze. The caller (of
+        // Otherwise it does not work on Windows. The caller (of
         // this method) is responsible for making sure that the
         // "-javahome" argument is first in the 'optArgs' string.
         //
@@ -946,16 +939,29 @@ public class JMSAdminImpl implements JMSAdmin, ExceptionListener {
         // handling on solaris.
         //
 
-        String cmdLine = iMQBrokerPath;
+        Vector v = new Vector();
+        if (java.io.File.separator.equals("\\")) {
+            v.add("cmd.exe");
+            v.add("/c");
+        }
+        v.add(iMQBrokerPath);
         if (optArgs != null) {
-            cmdLine = cmdLine + " " + optArgs;
+            for (String arg : optArgs.trim().split("\\s+")) {
+                if (!arg.isEmpty()) {
+                    v.add(arg);
+                }
+            }
         }
         if (serverName != null) {
-            cmdLine = cmdLine + " -name " + serverName;
+            v.add("-name");
+            v.add(serverName);
         }
-        cmdLine = cmdLine + " -remove instance -silent -force";
+        v.add("-remove");
+        v.add("instance");
+        v.add("-silent");
+        v.add("-force");
 
-        Process p = Runtime.getRuntime().exec(cmdLine);
+        Process p = Runtime.getRuntime().exec((String[]) v.toArray(new String[0]));
 
         // Close the receiver end of stdout and stderr streams.
         // Otherwise the child process blocks while trying to
@@ -1017,9 +1023,9 @@ public class JMSAdminImpl implements JMSAdmin, ExceptionListener {
         boolean interrupted = false;
 
         if (java.io.File.separator.equals("\\")) {
-            // Windows path
-            // <mqBinDir>\\bin\\imqbrokerd.exe
-            iMQBrokerPath = mqBinDir + java.io.File.separator + "imqbrokerd.exe";
+            // Windows path - .bat files require cmd.exe /c to execute from Java
+            // <mqBinDir>\imqbrokerd.bat
+            iMQBrokerPath = mqBinDir + java.io.File.separator + "imqbrokerd.bat";
         } else {
             // Unix path.
             // <mqBinDir>/bin/imqbrokerd
@@ -1034,7 +1040,7 @@ public class JMSAdminImpl implements JMSAdmin, ExceptionListener {
         // constraints -
         //
         // 1. The "-javahome" argument, if present, must be first.
-        // Otherwise it does not work on Windoze. The caller (of
+        // Otherwise it does not work on Windows. The caller (of
         // this method) is responsible for making sure that the
         // "-javahome" argument is first in the 'optArgs' string.
         //
@@ -1047,6 +1053,10 @@ public class JMSAdminImpl implements JMSAdmin, ExceptionListener {
         //
 
         Vector v = new Vector();
+        if (java.io.File.separator.equals("\\")) {
+            v.add("cmd.exe");
+            v.add("/c");
+        }
         v.add(iMQBrokerPath);
 
         if (optArgs != null) {

--- a/mq/main/mq-admin/mqadmin-gui/pom.xml
+++ b/mq/main/mq-admin/mqadmin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqadmin-gui</artifactId>

--- a/mq/main/mq-admin/mqadmin-gui/pom.xml
+++ b/mq/main/mq-admin/mqadmin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqadmin-gui</artifactId>

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-admin</artifactId>

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-admin</artifactId>

--- a/mq/main/mq-broker/mq-cluster/pom.xml
+++ b/mq/main/mq-broker/mq-cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-cluster</artifactId>

--- a/mq/main/mq-broker/mq-cluster/pom.xml
+++ b/mq/main/mq-broker/mq-cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-cluster</artifactId>

--- a/mq/main/mq-broker/mq-partition/mqpartition-persist-api/pom.xml
+++ b/mq/main/mq-broker/mq-partition/mqpartition-persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpartition-persist-api</artifactId>

--- a/mq/main/mq-broker/mq-partition/mqpartition-persist-api/pom.xml
+++ b/mq/main/mq-broker/mq-partition/mqpartition-persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqpartition-persist-api</artifactId>

--- a/mq/main/mq-broker/mq-partition/mqpartition-persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/mq-partition/mqpartition-persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqpartition-persist-jdbc</artifactId>

--- a/mq/main/mq-broker/mq-partition/mqpartition-persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/mq-partition/mqpartition-persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpartition-persist-jdbc</artifactId>

--- a/mq/main/mq-broker/mq-partition/pom.xml
+++ b/mq/main/mq-broker/mq-partition/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/mq-partition/pom.xml
+++ b/mq/main/mq-broker/mq-partition/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/mqbroker-comm/pom.xml
+++ b/mq/main/mq-broker/mqbroker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqbroker-comm</artifactId>

--- a/mq/main/mq-broker/mqbroker-comm/pom.xml
+++ b/mq/main/mq-broker/mqbroker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbroker-comm</artifactId>

--- a/mq/main/mq-broker/mqbroker-core/pom.xml
+++ b/mq/main/mq-broker/mqbroker-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/mqbroker-core/pom.xml
+++ b/mq/main/mq-broker/mqbroker-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/mqpersist-file/pom.xml
+++ b/mq/main/mq-broker/mqpersist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqpersist-file</artifactId>

--- a/mq/main/mq-broker/mqpersist-file/pom.xml
+++ b/mq/main/mq-broker/mqpersist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpersist-file</artifactId>

--- a/mq/main/mq-broker/mqpersist-jdbc/pom.xml
+++ b/mq/main/mq-broker/mqpersist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqpersist-jdbc</artifactId>

--- a/mq/main/mq-broker/mqpersist-jdbc/pom.xml
+++ b/mq/main/mq-broker/mqpersist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpersist-jdbc</artifactId>

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-client</artifactId>

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-client</artifactId>

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-direct</artifactId>

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-direct</artifactId>

--- a/mq/main/mq-logger/pom.xml
+++ b/mq/main/mq-logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-logger</artifactId>

--- a/mq/main/mq-logger/pom.xml
+++ b/mq/main/mq-logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-logger</artifactId>

--- a/mq/main/mq-packager-opensource/build.xml
+++ b/mq/main/mq-packager-opensource/build.xml
@@ -351,6 +351,89 @@
 			</fileset>
 		</chmod>
 
+		<echo level="info" message="### Make directories under ${ws.binary.win32.dir}/opt" />
+		<mkdir dir="${ws.binary.win32.dir}/opt/lib/props/broker" />
+		<mkdir dir="${ws.binary.win32.dir}/opt/lib/dtd" />
+		<mkdir dir="${ws.binary.win32.dir}/opt/lib/images/admin" />
+		<mkdir dir="${ws.binary.win32.dir}/opt/lib/help" />
+		<mkdir dir="${ws.binary.win32.dir}/opt/lib/ext" />
+		<mkdir dir="${ws.binary.win32.dir}/opt/etc" />
+		<mkdir dir="${ws.binary.win32.dir}/opt/bin" />
+
+		<echo level="info" message="### ${ws.binary.win32.dir}/opt/etc/" />
+		<copy todir="${ws.binary.win32.dir}/opt/etc/">
+			<fileset dir="${ws.top.dir}/src/win32/etc/">
+				<include name="imqenv.conf" />
+			</fileset>
+		</copy>
+		<copy todir="${ws.binary.win32.dir}/opt/etc/">
+			<fileset dir="${ws.top.dir}/src/share/etc/">
+				<include name="passfile.sample" />
+			</fileset>
+		</copy>
+
+		<echo level="info" message="### ${ws.binary.win32.dir}/opt/lib/props/" />
+		<copy todir="${ws.binary.win32.dir}/opt/lib/props/broker">
+			<fileset dir="${ws.top.dir}/src/share/props/broker/">
+				<include name="default.properties" />
+				<include name="install.properties" />
+			</fileset>
+		</copy>
+
+		<echo level="info" message="### ${ws.binary.win32.dir}/opt/lib/images/" />
+		<copy todir="${ws.binary.win32.dir}/opt/lib/images/admin">
+			<fileset dir="${ws.top.dir}/src/share/lib/images/admin/">
+				<include name="*.gif" />
+			</fileset>
+		</copy>
+
+		<echo level="info" message="### ${ws.binary.win32.dir}/opt/lib/help/" />
+		<unzip src="${ws.top.dir}/main/helpfiles/target/helpfiles.jar"
+			dest="${ws.binary.win32.dir}/opt/lib/help" />
+
+		<echo level="info" message="### ${ws.binary.win32.dir}/opt/lib/ (imqinit)" />
+		<copy todir="${ws.binary.win32.dir}/opt/lib/">
+			<fileset dir="${ws.top.dir}/src/win32/lib">
+				<include name="imqinit.bat" />
+			</fileset>
+		</copy>
+
+		<echo level="info" message="### ${ws.binary.win32.dir}/opt/lib/dtd/" />
+		<copy todir="${ws.binary.win32.dir}/opt/lib/dtd">
+			<fileset
+				dir="${ws.top.dir}/main/bridge/mqbridge-jms/src/main/java/com/sun/messaging/bridge/service/jms/xml/">
+				<include name="sun_jmsbridge*.dtd" />
+			</fileset>
+		</copy>
+
+		<echo level="info" message="### ${ws.binary.win32.dir}/opt/bin/ (short-name aliases)" />
+		<copy todir="${ws.binary.win32.dir}/opt/bin/">
+			<fileset dir="${ws.top.dir}/src/win32/bin">
+				<include name="adminconsole.bat" />
+				<include name="broker.bat" />
+				<include name="bridgemgr.bat" />
+				<include name="dbmgr.bat" />
+				<include name="icmd.bat" />
+				<include name="ikeytool.bat" />
+				<include name="objmgr.bat" />
+				<include name="usermgr.bat" />
+			</fileset>
+		</copy>
+
+		<echo level="info" message="### ${ws.binary.win32.dir}/opt/bin/ (imq* canonical scripts)" />
+		<copy todir="${ws.binary.win32.dir}/opt/bin/">
+			<fileset dir="${ws.top.dir}/src/win32/bin">
+				<include name="imqadmin.bat" />
+				<include name="imqbridgemgr.bat" />
+				<include name="imqbrokerd.bat" />
+				<include name="imqcmd.bat" />
+				<include name="imqdbmgr.bat" />
+				<include name="imqkeytool.bat" />
+				<include name="imqobjmgr.bat" />
+				<include name="imqusermgr.bat" />
+			</fileset>
+		</copy>
+
 		<echo level="info" message="### " />
 		<echo level="info" message="### Copy javahelp.jar to jhall.jar for gmake build" />
 

--- a/mq/main/mq-packager-opensource/pom.xml
+++ b/mq/main/mq-packager-opensource/pom.xml
@@ -37,6 +37,7 @@
         <ws.dist.bundles.dir>../../dist/bundles</ws.dist.bundles.dir>
         <ws.binary.share.dir>../../binary/share</ws.binary.share.dir>
         <ws.binary.solaris.dir>../../binary/solaris</ws.binary.solaris.dir>
+        <ws.binary.win32.dir>../../binary/win32</ws.binary.win32.dir>
         <ws.binary.Linux.dir>../../binary/Linux</ws.binary.Linux.dir>
         <ws.binary.Darwin.dir>../../binary/Darwin</ws.binary.Darwin.dir>
         <ws.top.dir>${basedir}/../..</ws.top.dir>

--- a/mq/main/mq-packager-opensource/pom.xml
+++ b/mq/main/mq-packager-opensource/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/mq-packager-opensource/pom.xml
+++ b/mq/main/mq-packager-opensource/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/mq-portunif/pom.xml
+++ b/mq/main/mq-portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-portunif</artifactId>

--- a/mq/main/mq-portunif/pom.xml
+++ b/mq/main/mq-portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-portunif</artifactId>

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-share</artifactId>

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-share</artifactId>

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-ums</artifactId>

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-ums</artifactId>

--- a/mq/main/mqcomm-io/pom.xml
+++ b/mq/main/mqcomm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqcomm-io</artifactId>

--- a/mq/main/mqcomm-io/pom.xml
+++ b/mq/main/mqcomm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqcomm-io</artifactId>

--- a/mq/main/mqcomm-util/pom.xml
+++ b/mq/main/mqcomm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqcomm-util</artifactId>

--- a/mq/main/mqcomm-util/pom.xml
+++ b/mq/main/mqcomm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqcomm-util</artifactId>

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqjmx-api</artifactId>

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmx-api</artifactId>

--- a/mq/main/persist/mq-txnlog/pom.xml
+++ b/mq/main/persist/mq-txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mq-txnlog</artifactId>

--- a/mq/main/persist/mq-txnlog/pom.xml
+++ b/mq/main/persist/mq-txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-txnlog</artifactId>

--- a/mq/main/persist/mqdisk-io/pom.xml
+++ b/mq/main/persist/mqdisk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqdisk-io</artifactId>

--- a/mq/main/persist/mqdisk-io/pom.xml
+++ b/mq/main/persist/mqdisk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>mqdisk-io</artifactId>

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
     </parent>
 
     <artifactId>persist</artifactId>

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
     </parent>
 
     <artifactId>persist</artifactId>

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.8.0.payara-p3-SNAPSHOT</version>
+        <version>6.8.0.payara-p3</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.8.0.payara-p3</version>
+        <version>6.8.0.payara-p4-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/src/buildant/distrules.xml
+++ b/mq/src/buildant/distrules.xml
@@ -140,10 +140,56 @@
 			</fileset>
 		</copy>
 		<chmod file="${mq.zip.installdir}/bin/imq*" perm="755"/>
+		<!-- .bat files for Windows -->
+		<copy tofile="${mq.zip.installdir}/bin/imqadmin.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqadmin.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqbridgemgr.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqbridgemgr.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqbrokerd.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqbrokerd.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqcmd.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqcmd.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqdbmgr.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqdbmgr.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqkeytool.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqkeytool.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqobjmgr.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqobjmgr.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqusermgr.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqusermgr.bat"/>
+			</fileset>
+		</copy>
 
 		<!-- lib dir -->
 		<echo level="info" message="### lib files"/>
 		<mkdir dir="${mq.zip.installdir}/lib"/>
+		<copy tofile="${mq.zip.installdir}/lib/imqinit.bat">
+			<fileset dir="${base_src.dir}/win32/lib">
+				<include name="imqinit.bat"/>
+			</fileset>
+		</copy>
 
 		<copy todir="${mq.zip.installdir}/lib">
 			<fileset dir="${classes.dir}">
@@ -645,10 +691,56 @@
 			</fileset>
 		</copy>
 		<chmod file="${mq.zip.installdir}/bin/imq*" perm="755"/>
+		<!-- .bat files for Windows -->
+		<copy tofile="${mq.zip.installdir}/bin/imqadmin.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqadmin.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqbridgemgr.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqbridgemgr.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqbrokerd.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqbrokerd.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqcmd.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqcmd.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqdbmgr.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqdbmgr.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqkeytool.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqkeytool.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqobjmgr.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqobjmgr.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqusermgr.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqusermgr.bat"/>
+			</fileset>
+		</copy>
 
 		<!-- lib dir -->
 		<echo level="info" message="### lib files"/>
 		<mkdir dir="${mq.zip.installdir}/lib"/>
+		<copy tofile="${mq.zip.installdir}/lib/imqinit.bat">
+			<fileset dir="${base_src.dir}/win32/lib">
+				<include name="imqinit.bat"/>
+			</fileset>
+		</copy>
 
 		<copy todir="${mq.zip.installdir}/lib">
 			<fileset dir="${classes.dir}">
@@ -1027,10 +1119,56 @@ IMQ_DEFAULT_VARHOME=../../glassfish/domains/domain1/imq]]>
 			</fileset>
 		</copy>
 		<chmod file="${mq.zip.installdir}/bin/imq*" perm="755"/>
+		<!-- .bat files for Windows -->
+		<copy tofile="${mq.zip.installdir}/bin/imqadmin.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqadmin.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqbridgemgr.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqbridgemgr.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqbrokerd.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqbrokerd.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqcmd.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqcmd.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqdbmgr.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqdbmgr.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqkeytool.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqkeytool.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqobjmgr.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqobjmgr.bat"/>
+			</fileset>
+		</copy>
+		<copy tofile="${mq.zip.installdir}/bin/imqusermgr.bat">
+			<fileset dir="${base_src.dir}/win32/bin">
+				<include name="imqusermgr.bat"/>
+			</fileset>
+		</copy>
 
 		<!-- lib dir -->
 		<echo level="info" message="### lib files"/>
 		<mkdir dir="${mq.zip.installdir}/lib"/>
+		<copy tofile="${mq.zip.installdir}/lib/imqinit.bat">
+			<fileset dir="${base_src.dir}/win32/lib">
+				<include name="imqinit.bat"/>
+			</fileset>
+		</copy>
 
 		<copy todir="${mq.zip.installdir}/lib">
 			<fileset dir="${classes.dir}">

--- a/mq/src/win32/bin/imqadmin.bat
+++ b/mq/src/win32/bin/imqadmin.bat
@@ -1,0 +1,42 @@
+@echo off
+REM
+REM  Copyright (c) 2026 Contributors to the Eclipse Foundation
+REM
+REM  This program and the accompanying materials are made available under the
+REM  terms of the Eclipse Public License v. 2.0, which is available at
+REM  http://www.eclipse.org/legal/epl-2.0.
+REM
+REM  This Source Code may also be made available under the following Secondary
+REM  Licenses when the conditions for such availability set forth in the
+REM  Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+REM  version 2 with the GNU Classpath Exception, which is available at
+REM  https://www.gnu.org/software/classpath/license.html.
+REM
+REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+REM
+
+REM
+REM JMS Administration Console startup script
+REM
+
+setlocal
+set _mainclass=com.sun.messaging.jmq.admin.apps.console.AdminConsole
+
+call "%~dp0..\lib\imqinit.bat" %*
+if ERRORLEVEL 1 goto end
+
+set JVM_ARGS=-Xmx128m "-Dimq.home=%IMQ_HOME%" "-Dimq.varhome=%IMQ_VARHOME%" "-Dimq.libhome=%IMQ_LIBHOME%"
+
+if "%CLASSPATH%" == "" (
+    set _classes=%IMQ_HOME%\lib\imqadmin.jar;%IMQ_HOME%\lib\fscontext.jar;%IMQ_HOME%\lib\jhall.jar;%IMQ_HOME%\lib\help
+) else (
+    set _classes=%IMQ_HOME%\lib\imqadmin.jar;%IMQ_HOME%\lib\fscontext.jar;%IMQ_HOME%\lib\jhall.jar;%IMQ_HOME%\lib\help;%CLASSPATH%
+    set CLASSPATH=
+)
+if not "%IMQ_EXT_JARS%" == "" set _classes=%_classes%;%IMQ_EXT_JARS%
+
+"%JAVA_HOME%\bin\java" -cp "%_classes%" %JVM_ARGS% %_mainclass% %*
+
+:end
+endlocal
+EXIT /b %ERRORLEVEL%

--- a/mq/src/win32/bin/imqbridgemgr.bat
+++ b/mq/src/win32/bin/imqbridgemgr.bat
@@ -1,0 +1,36 @@
+@echo off
+REM
+REM  Copyright (c) 2026 Contributors to the Eclipse Foundation
+REM
+REM  This program and the accompanying materials are made available under the
+REM  terms of the Eclipse Public License v. 2.0, which is available at
+REM  http://www.eclipse.org/legal/epl-2.0.
+REM
+REM  This Source Code may also be made available under the following Secondary
+REM  Licenses when the conditions for such availability set forth in the
+REM  Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+REM  version 2 with the GNU Classpath Exception, which is available at
+REM  https://www.gnu.org/software/classpath/license.html.
+REM
+REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+REM
+
+REM
+REM MQ Bridge Administration (command line) startup script
+REM
+
+setlocal
+set _mainclass=com.sun.messaging.bridge.admin.bridgemgr.BridgeMgr
+
+call "%~dp0..\lib\imqinit.bat" %*
+if ERRORLEVEL 1 goto end
+
+set JVM_ARGS=-Xmx128m "-Dimq.home=%IMQ_HOME%" "-Dimq.varhome=%IMQ_VARHOME%"
+set _classes=%IMQ_HOME%\lib\imqbridgemgr.jar
+if not "%IMQ_EXT_JARS%" == "" set _classes=%_classes%;%IMQ_EXT_JARS%
+
+"%JAVA_HOME%\bin\java" -cp "%_classes%" %JVM_ARGS% %_mainclass% %*
+
+:end
+endlocal
+EXIT /b %ERRORLEVEL%

--- a/mq/src/win32/bin/imqbrokerd.bat
+++ b/mq/src/win32/bin/imqbrokerd.bat
@@ -1,0 +1,94 @@
+@echo off
+REM
+REM  Copyright (c) 2026 Contributors to the Eclipse Foundation
+REM
+REM  This program and the accompanying materials are made available under the
+REM  terms of the Eclipse Public License v. 2.0, which is available at
+REM  http://www.eclipse.org/legal/epl-2.0.
+REM
+REM  This Source Code may also be made available under the following Secondary
+REM  Licenses when the conditions for such availability set forth in the
+REM  Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+REM  version 2 with the GNU Classpath Exception, which is available at
+REM  https://www.gnu.org/software/classpath/license.html.
+REM
+REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+REM
+
+REM
+REM Broker startup script
+REM Script specific properties:
+REM   -autorestart  Restart broker on abnormal exit
+REM   -managed      Broker is managed by an external process (suppresses autorestart)
+REM   -verbose      Print the launch command before starting
+REM
+
+setLocal ENABLEDELAYEDEXPANSION
+set _mainclass=com.sun.messaging.jmq.jmsserver.Broker
+
+call "%~dp0..\lib\imqinit.bat" %*
+if ERRORLEVEL 1 goto end
+
+set IMQ_EXTERNAL=%IMQ_HOME%\lib\ext
+set _def_jvm_args=-Xms192m -Xmx192m -Xss256k
+set JVM_ARGS=
+set BKR_ARGS=
+set _AUTORESTART=
+set _MANAGED=
+set _BGND=
+set args_list=%*
+
+:processArgs
+FOR /f "tokens=1,2* delims= " %%a IN ("%args_list%") DO (
+  if "%%a" == "-vmargs"      ( set JVM_ARGS=%JVM_ARGS% %%b&set args_list=%%c&goto :processArgs )
+  if "%%a" == "-autorestart" ( set _AUTORESTART=true&set args_list=%%b %%c&goto :processArgs )
+  if "%%a" == "-managed"     ( set _MANAGED=true&set args_list=%%b %%c&goto :processArgs )
+  if "%%a" == "-verbose"     ( set IMQ_VERBOSE=true&set args_list=%%b %%c&goto :processArgs )
+  if "%%a" == "-bgnd"        ( set _BGND=true&set BKR_ARGS=%BKR_ARGS% -bgnd&set args_list=%%b %%c&goto :processArgs )
+  if "%%a" == "-clientvm"    ( set args_list=%%b %%c&goto :processArgs )
+  set BKR_ARGS=%BKR_ARGS% %%a
+  set args_list=%%b %%c
+  goto :processArgs
+)
+:exitProcessArgs
+
+REM Create instances directory if it does not exist
+if not exist "%IMQ_VARHOME%\instances" mkdir "%IMQ_VARHOME%\instances"
+
+set JVM_ARGS=%_def_jvm_args% %JVM_ARGS% -XX:MaxGCPauseMillis=5000 "-Dimq.home=%IMQ_HOME%" "-Dimq.varhome=%IMQ_VARHOME%" "-Dimq.etchome=%IMQ_ETCHOME%" "-Dimq.libhome=%IMQ_LIBHOME%"
+set _classes=%IMQ_HOME%\lib\imqbroker.jar;%IMQ_HOME%\lib\imqutil.jar;%IMQ_EXTERNAL%\*
+for %%f in ("%IMQ_EXTERNAL%\*.zip") do set _classes=!_classes!;%%f
+if not "%IMQ_EXT_JARS%" == "" set _classes=%_classes%;%IMQ_EXT_JARS%
+
+if "%IMQ_VERBOSE%" == "true" (
+    echo   IMQ_HOME    : %IMQ_HOME%
+    echo   IMQ_VARHOME : %IMQ_VARHOME%
+    echo Command:
+    echo   "%JAVA_HOME%\bin\java" -cp "%_classes%" %JVM_ARGS% %_mainclass% %BKR_ARGS%
+)
+
+:StartBroker
+"%JAVA_HOME%\bin\java" -cp "%_classes%" %JVM_ARGS% %_mainclass% %BKR_ARGS%
+set _status=%ERRORLEVEL%
+
+REM Exit code 255 means restart
+if %_status% == 255 (
+    if "%_MANAGED%" == "true" goto end
+    timeout /t 1 /nobreak > nul
+    goto StartBroker
+)
+
+REM Normal termination
+if %_status% == 0 goto end
+if %_status% == 1 goto end
+
+REM Abnormal termination - restart if -autorestart was specified
+if "%_AUTORESTART%" == "true" (
+    if not "%_MANAGED%" == "true" (
+        timeout /t 2 /nobreak > nul
+        goto StartBroker
+    )
+)
+
+:end
+endlocal & EXIT /b %_status%

--- a/mq/src/win32/bin/imqcmd.bat
+++ b/mq/src/win32/bin/imqcmd.bat
@@ -1,0 +1,36 @@
+@echo off
+REM
+REM  Copyright (c) 2026 Contributors to the Eclipse Foundation
+REM
+REM  This program and the accompanying materials are made available under the
+REM  terms of the Eclipse Public License v. 2.0, which is available at
+REM  http://www.eclipse.org/legal/epl-2.0.
+REM
+REM  This Source Code may also be made available under the following Secondary
+REM  Licenses when the conditions for such availability set forth in the
+REM  Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+REM  version 2 with the GNU Classpath Exception, which is available at
+REM  https://www.gnu.org/software/classpath/license.html.
+REM
+REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+REM
+
+REM
+REM Broker Administration (command line) startup script
+REM
+
+setlocal
+set _mainclass=com.sun.messaging.jmq.admin.apps.broker.BrokerCmd
+
+call "%~dp0..\lib\imqinit.bat" %*
+if ERRORLEVEL 1 goto end
+
+set JVM_ARGS=-Xmx128m "-Dimq.home=%IMQ_HOME%" "-Dimq.varhome=%IMQ_VARHOME%"
+set _classes=%IMQ_HOME%\lib\imqadmin.jar;%IMQ_HOME%\lib\fscontext.jar
+if not "%IMQ_EXT_JARS%" == "" set _classes=%_classes%;%IMQ_EXT_JARS%
+
+"%JAVA_HOME%\bin\java" -cp "%_classes%" %JVM_ARGS% %_mainclass% %*
+
+:end
+endlocal
+EXIT /b %ERRORLEVEL%

--- a/mq/src/win32/bin/imqdbmgr.bat
+++ b/mq/src/win32/bin/imqdbmgr.bat
@@ -1,0 +1,56 @@
+@echo off
+REM
+REM  Copyright (c) 2026 Contributors to the Eclipse Foundation
+REM
+REM  This program and the accompanying materials are made available under the
+REM  terms of the Eclipse Public License v. 2.0, which is available at
+REM  http://www.eclipse.org/legal/epl-2.0.
+REM
+REM  This Source Code may also be made available under the following Secondary
+REM  Licenses when the conditions for such availability set forth in the
+REM  Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+REM  version 2 with the GNU Classpath Exception, which is available at
+REM  https://www.gnu.org/software/classpath/license.html.
+REM
+REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+REM
+
+REM
+REM Message Queue Database Administration startup script
+REM
+REM Script specific properties:
+REM   -javahome <path>  Use <path> as the location of the Java runtime
+REM
+
+setlocal ENABLEDELAYEDEXPANSION
+set _mainclass=com.sun.messaging.jmq.jmsserver.persist.jdbc.DBTool
+
+call "%~dp0..\lib\imqinit.bat" %*
+if ERRORLEVEL 1 goto end
+
+set IMQ_EXTERNAL=%IMQ_HOME%\lib\ext
+set JVM_ARGS=
+set BKR_ARGS=
+set args_list=%*
+
+:processArgs
+FOR /f "tokens=1,2* delims= " %%a IN ("%args_list%") DO (
+  if "%%a" == "-javahome"  ( set args_list=%%c&goto :processArgs )
+  if "%%a" == "-vmargs"    ( set JVM_ARGS=%JVM_ARGS% %%b&set args_list=%%c&goto :processArgs )
+  if "%%a" == "-verbose"   ( set args_list=%%b %%c&goto :processArgs )
+  set BKR_ARGS=%BKR_ARGS% %%a
+  set args_list=%%b %%c
+  goto :processArgs
+)
+:exitProcessArgs
+
+set JVM_ARGS=-Xmx128m "-Dimq.home=%IMQ_HOME%" "-Dimq.varhome=%IMQ_VARHOME%" "-Dimq.libhome=%IMQ_LIBHOME%" "-Dimq.etchome=%IMQ_ETCHOME%" %JVM_ARGS%
+set _classes=%IMQ_HOME%\lib\imqbroker.jar;%IMQ_EXTERNAL%\*
+for %%f in ("%IMQ_EXTERNAL%\*.zip") do set _classes=!_classes!;%%f
+if not "%IMQ_EXT_JARS%" == "" set _classes=%_classes%;%IMQ_EXT_JARS%
+
+"%JAVA_HOME%\bin\java" -cp "%_classes%" %JVM_ARGS% %_mainclass% %BKR_ARGS%
+
+:end
+endlocal
+EXIT /b %ERRORLEVEL%

--- a/mq/src/win32/bin/imqkeytool.bat
+++ b/mq/src/win32/bin/imqkeytool.bat
@@ -1,0 +1,82 @@
+@echo off
+REM
+REM  Copyright (c) 2026 Contributors to the Eclipse Foundation
+REM
+REM  This program and the accompanying materials are made available under the
+REM  terms of the Eclipse Public License v. 2.0, which is available at
+REM  http://www.eclipse.org/legal/epl-2.0.
+REM
+REM  This Source Code may also be made available under the following Secondary
+REM  Licenses when the conditions for such availability set forth in the
+REM  Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+REM  version 2 with the GNU Classpath Exception, which is available at
+REM  https://www.gnu.org/software/classpath/license.html.
+REM
+REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+REM
+REM imqkeytool is a wrapper script for JDK Keytool for generation of a keystore
+REM and a self signed certificate for use with SSL.
+REM
+REM To generate keystore and self signed certificate for the broker
+REM usage: imqkeytool [-broker]
+REM
+REM To generate keystore and a self-signed certificate for the HTTPS tunnel
+REM servlet
+REM usage: imqkeytool -servlet <keystore location>
+REM
+
+setlocal
+set _cmd=broker
+set _keystore=
+set args_list=%*
+
+call "%~dp0..\lib\imqinit.bat" %*
+if ERRORLEVEL 1 goto end
+
+:processArgs
+FOR /f "tokens=1,2* delims= " %%a IN ("%args_list%") DO (
+  if "%%a" == "-javahome"  ( set args_list=%%c&goto :processArgs )
+  if "%%a" == "-jrehome"   ( set args_list=%%c&goto :processArgs )
+  if "%%a" == "-varhome"   ( set args_list=%%c&goto :processArgs )
+  if "%%a" == "-verbose"   ( set args_list=%%b %%c&goto :processArgs )
+  if "%%a" == "-broker"    ( set _cmd=broker&set args_list=%%b %%c&goto :processArgs )
+  if "%%a" == "-servlet"   ( set _cmd=servlet&set _keystore=%%b&set args_list=%%c&goto :processArgs )
+  if not "%%a" == "" goto usage
+)
+:exitProcessArgs
+
+if "%_cmd%" == "broker"  goto broker
+if "%_cmd%" == "servlet" goto servlet
+goto usage
+
+:broker
+echo Generating keystore for the broker ...
+set _KEYSTORE=%IMQ_ETCHOME%\keystore
+echo Keystore=%_KEYSTORE%
+"%JAVA_HOME%\bin\keytool" -v -genkey -keyalg "RSA" -alias imq -keystore "%_KEYSTORE%"
+goto end
+
+:servlet
+if "%_keystore%" == "" goto nopath
+echo Generating keystore for the HTTPS tunnel servlet ...
+echo Keystore=%_keystore%
+"%JAVA_HOME%\bin\keytool" -v -genkey -keyalg "RSA" -alias imqservlet -keystore "%_keystore%"
+if %ERRORLEVEL% == 0 (echo Make sure the keystore is accessible and readable by the HTTPS tunnel servlet.)
+goto end
+
+:nopath
+echo Please specify keystore location for the -servlet option
+goto usage
+
+:usage
+echo usage:
+echo imqkeytool [-broker]
+echo    generates a keystore and self-signed certificate for the broker
+echo imqkeytool -servlet keystore_location
+echo    generates a keystore and self-signed certificate for the HTTPS
+echo    tunnel servlet, keystore_location specifies the name and location
+echo    of the keystore file
+
+:end
+endlocal
+EXIT /b %ERRORLEVEL%

--- a/mq/src/win32/bin/imqobjmgr.bat
+++ b/mq/src/win32/bin/imqobjmgr.bat
@@ -1,0 +1,42 @@
+@echo off
+REM
+REM  Copyright (c) 2026 Contributors to the Eclipse Foundation
+REM
+REM  This program and the accompanying materials are made available under the
+REM  terms of the Eclipse Public License v. 2.0, which is available at
+REM  http://www.eclipse.org/legal/epl-2.0.
+REM
+REM  This Source Code may also be made available under the following Secondary
+REM  Licenses when the conditions for such availability set forth in the
+REM  Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+REM  version 2 with the GNU Classpath Exception, which is available at
+REM  https://www.gnu.org/software/classpath/license.html.
+REM
+REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+REM
+
+REM
+REM JMS Object Administration startup script
+REM
+
+setlocal
+set _mainclass=com.sun.messaging.jmq.admin.apps.objmgr.ObjMgr
+
+call "%~dp0..\lib\imqinit.bat" %*
+if ERRORLEVEL 1 goto end
+
+set JVM_ARGS=-Xmx128m "-Dimq.home=%IMQ_HOME%" "-Dimq.varhome=%IMQ_VARHOME%"
+
+if "%CLASSPATH%" == "" (
+    set _classes=%IMQ_HOME%\lib\imqadmin.jar;%IMQ_HOME%\lib\fscontext.jar
+) else (
+    set _classes=%IMQ_HOME%\lib\imqadmin.jar;%IMQ_HOME%\lib\fscontext.jar;%CLASSPATH%
+    set CLASSPATH=
+)
+if not "%IMQ_EXT_JARS%" == "" set _classes=%_classes%;%IMQ_EXT_JARS%
+
+"%JAVA_HOME%\bin\java" -cp "%_classes%" %JVM_ARGS% %_mainclass% %*
+
+:end
+endlocal
+EXIT /b %ERRORLEVEL%

--- a/mq/src/win32/bin/imqusermgr.bat
+++ b/mq/src/win32/bin/imqusermgr.bat
@@ -1,0 +1,36 @@
+@echo off
+REM
+REM  Copyright (c) 2026 Contributors to the Eclipse Foundation
+REM
+REM  This program and the accompanying materials are made available under the
+REM  terms of the Eclipse Public License v. 2.0, which is available at
+REM  http://www.eclipse.org/legal/epl-2.0.
+REM
+REM  This Source Code may also be made available under the following Secondary
+REM  Licenses when the conditions for such availability set forth in the
+REM  Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+REM  version 2 with the GNU Classpath Exception, which is available at
+REM  https://www.gnu.org/software/classpath/license.html.
+REM
+REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+REM
+
+REM
+REM Message Queue User Manager startup script
+REM
+
+setlocal
+set _mainclass=com.sun.messaging.jmq.jmsserver.auth.usermgr.UserMgr
+
+call "%~dp0..\lib\imqinit.bat" %*
+if ERRORLEVEL 1 goto end
+
+set JVM_ARGS=-Xmx128m "-Dimq.home=%IMQ_HOME%" "-Dimq.varhome=%IMQ_VARHOME%" "-Dimq.etchome=%IMQ_ETCHOME%" "-Dimq.libhome=%IMQ_LIBHOME%"
+set _classes=%IMQ_HOME%\lib\imqbroker.jar
+if not "%IMQ_EXT_JARS%" == "" set _classes=%_classes%;%IMQ_EXT_JARS%
+
+"%JAVA_HOME%\bin\java" -cp "%_classes%" %JVM_ARGS% %_mainclass% %*
+
+:end
+endlocal
+EXIT /b %ERRORLEVEL%

--- a/mq/src/win32/lib/imqinit.bat
+++ b/mq/src/win32/lib/imqinit.bat
@@ -1,0 +1,113 @@
+@echo off
+REM
+REM  Copyright (c) 2026 Contributors to the Eclipse Foundation
+REM
+REM  This program and the accompanying materials are made available under the
+REM  terms of the Eclipse Public License v. 2.0, which is available at
+REM  http://www.eclipse.org/legal/epl-2.0.
+REM
+REM  This Source Code may also be made available under the following Secondary
+REM  Licenses when the conditions for such availability set forth in the
+REM  Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+REM  version 2 with the GNU Classpath Exception, which is available at
+REM  https://www.gnu.org/software/classpath/license.html.
+REM
+REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+REM
+
+REM
+REM Common initialization script used by all imq wrapper scripts.
+REM Must be invoked with CALL and all caller args: call imqinit.bat %*
+REM Must NOT use setlocal so that variables persist to the calling script.
+REM
+REM After this script runs the following variables are defined:
+REM
+REM   JAVA_HOME       Location of Java to use
+REM   IMQ_JAVAREASON  Where JAVA_HOME was resolved from
+REM   IMQ_HOME        Root of Message Queue installation
+REM   IMQ_ETCHOME     Root of etc subtree
+REM   IMQ_LIBHOME     Root of lib subtree
+REM   IMQ_VARHOME     Root of var subtree
+REM   IMQ_EXT_JARS    External JARs to include on the classpath
+REM   IMQ_VERBOSE     Set to "true" if -verbose was found in the args
+REM
+
+REM Determine IMQ_HOME from this script's location (lib\imqinit.bat -> parent = IMQ_HOME)
+set IMQ_HOME=%~dp0..
+
+REM Set directory defaults relative to IMQ_HOME
+if "%IMQ_ETCHOME%" == "" set IMQ_ETCHOME=%IMQ_HOME%\etc
+if "%IMQ_LIBHOME%" == "" set IMQ_LIBHOME=%IMQ_HOME%\lib
+if "%IMQ_VARHOME%" == "" set IMQ_VARHOME=%IMQ_HOME%\var
+
+REM Load imqenv.conf. Only lines beginning with "set IMQ_DEFAULT_" are processed,
+REM which are the active (uncommented) settings. REM-prefixed lines are ignored.
+if exist "%IMQ_ETCHOME%\imqenv.conf" (
+    for /f "usebackq tokens=*" %%a in (`findstr /b /i "set IMQ_DEFAULT_" "%IMQ_ETCHOME%\imqenv.conf" 2^>nul`) do %%a
+)
+
+REM Apply IMQ_DEFAULT_* variables loaded from imqenv.conf
+if not "%IMQ_DEFAULT_JAVAHOME%" == "" (
+    set JAVA_HOME=%IMQ_DEFAULT_JAVAHOME%
+    set IMQ_JAVAREASON=imqenv.conf
+    set IMQ_DEFAULT_JAVAHOME=
+)
+if not "%IMQ_DEFAULT_VARHOME%" == "" (
+    set IMQ_VARHOME=%IMQ_DEFAULT_VARHOME%
+    set IMQ_DEFAULT_VARHOME=
+)
+if not "%IMQ_DEFAULT_ETCHOME%" == "" (
+    set IMQ_ETCHOME=%IMQ_DEFAULT_ETCHOME%
+    set IMQ_DEFAULT_ETCHOME=
+)
+if not "%IMQ_DEFAULT_EXT_JARS%" == "" (
+    set IMQ_EXT_JARS=%IMQ_DEFAULT_EXT_JARS%
+    set IMQ_DEFAULT_EXT_JARS=
+)
+
+REM Override JAVA_HOME with IMQ_JAVAHOME environment variable
+if not "%IMQ_JAVAHOME%" == "" (
+    set JAVA_HOME=%IMQ_JAVAHOME%
+    set IMQ_JAVAREASON=IMQ_JAVAHOME
+)
+
+REM Scan caller args for -javahome, -jrehome, -varhome, -verbose.
+REM This mirrors imqinit reading $@ without consuming from it:
+REM the caller's %* is unchanged and will be passed through to Java as-is.
+set _imq_args=%*
+:_imqinit_scan
+for /f "tokens=1,2* delims= " %%a in ("%_imq_args%") do (
+    if /i "%%a" == "-javahome" ( set JAVA_HOME=%%b&set IMQ_JAVAREASON=-javahome&set _imq_args=%%c&goto :_imqinit_scan )
+    if /i "%%a" == "-jrehome"  ( set JAVA_HOME=%%b&set IMQ_JAVAREASON=-jrehome&set _imq_args=%%c&goto :_imqinit_scan )
+    if /i "%%a" == "-varhome"  ( set IMQ_VARHOME=%%b&set _imq_args=%%c&goto :_imqinit_scan )
+    if /i "%%a" == "-verbose"  ( set IMQ_VERBOSE=true&set _imq_args=%%b %%c&goto :_imqinit_scan )
+    if not "%%a" == ""         ( set _imq_args=%%b %%c&goto :_imqinit_scan )
+)
+set _imq_args=
+
+REM Validate Java location
+if "%JAVA_HOME%" == "" (
+    echo Error: Java location not set.
+    echo Set JAVA_HOME, IMQ_JAVAHOME, or pass -javahome to specify the Java runtime.
+    EXIT /b 1
+)
+if not exist "%JAVA_HOME%\bin\java.exe" (
+    echo Error: Invalid Java location: %JAVA_HOME%
+    echo Java location was specified using: %IMQ_JAVAREASON%
+    EXIT /b 1
+)
+
+REM Verbose output (mirrors imqinit verbose block)
+if "%IMQ_VERBOSE%" == "true" (
+    echo.
+    echo Environment is:
+    echo     Java location     : %JAVA_HOME%
+    echo     Java specified by : %IMQ_JAVAREASON%
+    echo     IMQ_HOME          : %IMQ_HOME%
+    echo     IMQ_VARHOME       : %IMQ_VARHOME%
+    echo     IMQ_ETCHOME       : %IMQ_ETCHOME%
+    echo     IMQ_LIBHOME       : %IMQ_LIBHOME%
+    echo     IMQ_EXT_JARS      : %IMQ_EXT_JARS%
+)
+
+EXIT /b 0

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>6.8.0.payara-p3</version>
+    <version>6.8.0.payara-p4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>MQ Parent Project</name>
@@ -87,7 +87,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.outputTimestamp>2026-05-15T10:57:41Z</project.build.outputTimestamp>
+        <project.build.outputTimestamp>2026-05-15T10:58:57Z</project.build.outputTimestamp>
         <pmd.version>7.21.0</pmd.version>
         <pmd.plugin.version>3.28.0</pmd.plugin.version>
         <spotbugs.version>4.9.8</spotbugs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>6.8.0.payara-p3-SNAPSHOT</version>
+    <version>6.8.0.payara-p3</version>
     <packaging>pom</packaging>
 
     <name>MQ Parent Project</name>
@@ -87,7 +87,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.outputTimestamp>2026-04-17T13:47:05Z</project.build.outputTimestamp>
+        <project.build.outputTimestamp>2026-05-15T10:57:41Z</project.build.outputTimestamp>
         <pmd.version>7.21.0</pmd.version>
         <pmd.plugin.version>3.28.0</pmd.plugin.version>
         <spotbugs.version>4.9.8</spotbugs.version>


### PR DESCRIPTION
OpenMQ's Windows tooling previously relied on .exe wrappers (imqbrokersvc.exe, imqbrokerd.exe) that are no longer shipped. This PR replaces them with .bat scripts equivalent to the existing Unix shell scripts, making the broker and all admin tools functional on Windows.

The changes include a shared imqinit.bat initialization library (mirroring the Unix imqinit) and related imq*.bat launchers for all eight tools. JMSAdminImpl.java is updated to launch cmd.exe /c imqbrokerd.bat instead of the missing .exe files; this also fixes a deprecated Runtime.exec(String) call and improves argument splitting for optArgs. The build (build.xml, pom.xml, distrules.xml) is updated to include these files in the Windows binary layout and ZIP distribution.

These changes were tested manually on a Windows environment 

SNAPSHOT is available in staging and I will release once approved.
